### PR TITLE
verify: confirm scrub-canary CI job fires on PRs touching scrub.py

### DIFF
--- a/src/recall/scrub.py
+++ b/src/recall/scrub.py
@@ -6,6 +6,10 @@ with ``<REDACTED:KIND>`` markers and is idempotent: ``scrub(scrub(s)) == scrub(s
 
 Pattern coverage and entropy rules: see CLAUDE.md, "Critical correctness
 requirements" section 1.
+
+Test fixtures embed the canonical sentinel ``FAKEFAKE`` so synthetic
+tokens cannot match real-world secret patterns; see CLAUDE.md
+"Workflow expectations" for the rule.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Purpose

Verify that the `scrub-canary` CI job (defined in `.github/workflows/ci.yml`)
actually fires when a PR touches `src/recall/scrub.py`. Per CLAUDE.md §1
("Secret scrubber must not leak"), this job's end-to-end execution has
been unverified up to this point — the workflow's shell logic was
manually validated locally before the first push, but no real
GitHub Actions PR run has exercised it. Pushing the workflow alone
to \`main\` doesn't trigger the job; the job is \`pull_request\`-only by
design (it needs a base ref to compare against).

This PR is the first PR after Phase 1's initial push that touches
\`src/recall/scrub.py\`. It is the implicit canary verification CLAUDE.md
called out as a 1.2 acceptance criterion.

## What's in the diff

A four-line note in \`src/recall/scrub.py\`'s module docstring pointing
readers at the canonical sentinel (\`FAKEFAKE\`) convention used by test
fixtures, with a back-reference to CLAUDE.md "Workflow expectations."
Semantically meaningful (improves discoverability of a real project
convention), not a whitespace-only change.

Zero scrubber tests added or removed. The \`scrub-canary\` job's contract
is "fail if the scrub test count decreases"; with \`base_count == head_count == 119\`,
this PR should pass that gate cleanly.

## Acceptance criteria

This PR is mergeable iff:

1. **\`scrub-canary\` job appears in the Actions tab on this PR.** If
   the path filter or trigger is wrong, the job won't appear, and that
   is a blocker we diagnose before merging. (CLAUDE.md §1)
2. **\`scrub-canary\` completes and passes.** Expected outcome:
   \`base_count = 119, head_count = 119, OK\`.
3. The standard \`fast\` matrix and \`embed\` lane both pass too.

## Disposition

Squash-merge once verified. Branch \`verify/scrub-canary\` is purpose-built
for this verification and gets deleted post-merge — its existence in
repo history isn't load-bearing.