### PR TITLE
feat(indexer): HistorySource → scrubber → embedder → DB write (Commit 2.8) — verify branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,23 @@ expose exactly one method:
 - Sources are stateless across calls. Each `iter_entries` opens whatever
   file or DB it needs and closes when the iterator is exhausted.
 
+**Indexer cursor schema (added 2.8).** The indexer stores per-source
+incremental cursors in the `meta` table under keys named
+`cursor_<source>` — e.g. `cursor_zsh`, `cursor_bash`, `cursor_atuin`.
+Each value is the wall-clock unix-second timestamp of the last entry
+successfully committed for that source. **Adding a new source means
+adding a new `cursor_<name>` key, not migrating existing data** —
+older sources' cursors are unaffected; the new source starts at None
+(== "from the beginning").
+
+The cursor advances atomically with the row inserts it represents
+(within the same transaction). On crash mid-batch, the cursor stays
+at the last successfully committed batch's max ts — the next
+indexing run re-processes only entries the previous run hadn't
+committed. Entries with `ts = 0` (unknown timestamp) are always
+yielded by sources regardless of cursor and never advance the cursor;
+the `UNIQUE(source, text_hash, ts)` constraint backstops dedup.
+
 ### 3. atuin schema robustness
 
 Open the user's atuin database with `?mode=ro&immutable=1` so we never write
@@ -351,7 +368,14 @@ for orchestrating "clear → rotate → re-index." Mechanism vs. policy.
 
 - Cold start (model load + db open): < 2 s on M-series Mac
 - Single semantic query over 50k commands: < 100 ms p95
-- Initial index of 50k commands: < 60 s
+- Initial index of 50k commands: < 60 s **on M-series Mac only**
+  (added 2.8). Indexer is encode-bound on Linux per the 2.7
+  platform-divergence finding; Linux indexing throughput is bounded
+  by Embedder throughput, which is itself constrained by the
+  platform-balanced batch=64 default (CLAUDE.md §6 "Platform-divergent
+  optimal batch sizes"). Linux empirical number recorded post-impl;
+  no Linux gate enforced — the constraint chain runs through the
+  Embedder, not the indexer.
 - Eval harness (`recall eval --dataset nl2bash`): ≤ 60 s on M-series Mac
   (target). Soft warning printed at 90 s; hard fail (raised by the harness
   itself, not just CI) at 120 s. The hard fail makes the runtime gate live
@@ -523,8 +547,23 @@ arbitrary direction — see "Phase 2 gating rules" below)*
       before 2.8 starts** — indexer adds eval-lane content that
       compounds existing CI pressure.
 - 2.8 Indexer: `HistorySource` → scrubber → embedder → DB write,
-      respecting the architectural seam
-- 2.9 Hybrid search (vector + FTS5 with RRF k=60)
+      respecting the architectural seam. Per-source ts cursor in
+      `meta`; 1024-row indexer batches feeding the embedder's
+      internal batch_size=64; `--rebuild` does DROP + CREATE
+      (well-tested vec0 reset path); `--new-salt` requires `--rebuild`.
+      Adversarial scrubber-integration test asserts zero secret-pattern
+      matches in `commands.text_scrubbed` after indexing the
+      synthetic-secrets corpus. **Indexer is consumer-less until Phase
+      3's MCP server lands** — integration tests verify DB-layer
+      correctness; user-facing round-trip ("index → search via MCP
+      tool") is gated on Phase 3 and added then.
+- 2.9 Hybrid search (vector + FTS5 with RRF k=60). **Sequencing
+      question deferred to surface after 2.8 ships**: hybrid is
+      marginal-gain given current 1.11×/4× recall numbers; Phase 3
+      MCP server is the delivered product. Decision pending after
+      2.8 produces actual indexer behavior to inform: should 2.9
+      ship before Phase 3, or can Phase 3 v1 ship with vector-only
+      and 2.9 land as v1.1?
 
 **Phase 3 — MCP surface**
 - 3.9  `server.py` + `tools.py` with the six tools

--- a/src/recall/cli.py
+++ b/src/recall/cli.py
@@ -455,14 +455,132 @@ def eval_cmd(
 
 
 @app.command(name="index")
-def index_cmd() -> None:
-    """Index shell history into the local SQLite store. Lands in Commit 2.8."""
-    typer.secho(
-        "recall index is not yet implemented (lands in Commit 2.8 — the indexer).",
-        fg=typer.colors.YELLOW,
-        err=True,
-    )
-    raise typer.Exit(2)
+def index_cmd(
+    source: Annotated[
+        str,
+        typer.Option(
+            help="Source(s) to index: all | zsh | bash | atuin. "
+            "Default 'all' indexes every available source sequentially. "
+            "Sources without a usable history (e.g. atuin not installed) "
+            "are skipped with a warning."
+        ),
+    ] = "all",
+    rebuild: Annotated[
+        bool,
+        typer.Option(
+            "--rebuild",
+            help="Drop and re-create commands/commands_vec/commands_fts before "
+            "indexing (CLAUDE.md §4b). Salt preserved unless --new-salt also "
+            "passed. Cursor metas reset; all sources re-index from scratch.",
+        ),
+    ] = False,
+    new_salt: Annotated[
+        bool,
+        typer.Option(
+            "--new-salt",
+            help="Rotate the dedup salt (CLAUDE.md §4b). Requires --rebuild — "
+            "rotating the salt without rebuilding leaves old-salt and new-salt "
+            "hashes coexisting in one table, silently breaking dedup.",
+        ),
+    ] = False,
+) -> None:
+    """Index shell history into the local SQLite store at ``~/.recall/db.sqlite``.
+
+    Pulls entries from each source's ``iter_entries`` (incremental from
+    the per-source cursor in meta), runs each through the scrubber,
+    embeds the scrubbed text via ``Embedder``, and writes
+    (text_scrubbed, text_hash, vector, metadata) rows in 1024-row
+    transactions (CLAUDE.md §2.8).
+    """
+    # Lazy-import indexer + sources here (not at module top) to keep
+    # `recall --help`, `recall eval`, and pytest collection from paying
+    # the model-load cost when the user just wanted the eval lane.
+    # Same lesson as Embedder's lazy sentence-transformers import in 2.5.
+    import logging
+
+    from recall.db import connect, migrate, rotate_dedup_salt
+    from recall.embed import Embedder
+    from recall.indexer import index_sources
+    from recall.indexer import rebuild as do_rebuild
+    from recall.sources.atuin import AtuinSchemaError, AtuinSource
+    from recall.sources.base import HistorySource
+    from recall.sources.bash import BashSource
+    from recall.sources.zsh import ZshSource
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
+
+    if new_salt and not rebuild:
+        typer.secho(
+            "--new-salt without --rebuild is rejected: rotating the salt without "
+            "rebuilding leaves old-salt and new-salt hashes coexisting in one "
+            "table, silently breaking dedup. Pass --rebuild together.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    valid_sources = {"all", "zsh", "bash", "atuin"}
+    if source not in valid_sources:
+        typer.secho(
+            f"unknown source: {source!r}; expected one of {sorted(valid_sources)}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    conn = connect()
+    migrate(conn)
+
+    if rebuild:
+        if new_salt:
+            rotate_dedup_salt(conn)
+        do_rebuild(conn)
+
+    # Resolve sources. Each source factory either returns a ready-to-use
+    # HistorySource or raises (missing histfile, atuin not installed, etc.)
+    # in which case we skip it with a warning. Sequential per Q3.
+    requested = [source] if source != "all" else ["zsh", "bash", "atuin"]
+    active: list[HistorySource] = []
+    for name in requested:
+        try:
+            if name == "zsh":
+                active.append(ZshSource())
+            elif name == "bash":
+                active.append(BashSource())
+            elif name == "atuin":
+                active.append(AtuinSource())
+        except (FileNotFoundError, AtuinSchemaError) as e:
+            typer.secho(
+                f"skipping {name}: {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+
+    if not active:
+        typer.secho(
+            "no usable sources found. Did the histfiles get nuked?",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    typer.echo(f"recall index: sources={[s.name for s in active]} rebuild={rebuild}")
+
+    embedder = Embedder()
+    result = index_sources(conn, active, embedder=embedder)
+
+    typer.echo("")
+    typer.echo("=== Indexing summary ===")
+    typer.echo(f"  inserted:           {result.inserted}")
+    typer.echo(f"  skipped (dedup):    {result.skipped_dedup}")
+    typer.echo(f"  total processed:    {result.total_processed()}")
+    typer.echo("  by source:")
+    for src, n in result.by_source.items():
+        typer.echo(f"    {src:<8} {n}")
+    typer.echo("")
+    typer.echo(f"  runtime:            {result.runtime_seconds:.2f}s")
+    typer.echo(f"    embedder:         {result.embedder_seconds:.2f}s")
+    typer.echo(f"    db writes:        {result.db_write_seconds:.2f}s")
 
 
 @app.command(name="serve")

--- a/src/recall/db.py
+++ b/src/recall/db.py
@@ -212,15 +212,38 @@ def dedup_hash(salt: bytes, raw: str) -> bytes:
     return h.digest()
 
 
+def get_cursor(conn: sqlite3.Connection, source: str) -> int | None:
+    """Return the per-source incremental cursor (last-indexed wall-clock unix
+    seconds) for ``source``, or None if never indexed.
+
+    Convention (CLAUDE.md §2.8 indexer-cursor schema): meta key is
+    ``cursor_<source>``, e.g. ``cursor_zsh``. Adding a new source means
+    adding a new meta cursor key, not migrating existing data — older
+    sources' cursors are unaffected.
+    """
+    raw = get_meta(conn, f"cursor_{source}")
+    return None if raw is None else int(raw)
+
+
+def set_cursor(conn: sqlite3.Connection, source: str, ts: int) -> None:
+    """Update the per-source cursor to ``ts``. Caller wraps in a
+    transaction for atomicity with the row inserts the cursor advance
+    refers to (CLAUDE.md "Architectural seams": cursor advance and the
+    DB writes it represents must commit together)."""
+    set_meta(conn, f"cursor_{source}", str(ts))
+
+
 __all__ = (
     "DBError",
     "connect",
     "dedup_hash",
     "dedup_salt",
+    "get_cursor",
     "get_meta",
     "migrate",
     "rotate_dedup_salt",
     "schema_version",
+    "set_cursor",
     "set_meta",
     "transaction",
 )

--- a/src/recall/indexer.py
+++ b/src/recall/indexer.py
@@ -1,0 +1,405 @@
+"""Indexer: source → scrubber → embedder → DB write.
+
+The orchestration layer. Pulls entries from one or more
+``HistorySource`` instances, runs each through the scrubber, hashes
+the scrubbed text under the dedup salt, and writes
+(text_scrubbed, text_hash, vector, metadata) to ``commands`` +
+``commands_vec`` in batched transactions.
+
+ARCHITECTURAL INVARIANT (LOCKED Q1, CLAUDE.md §1)
+
+    Everything below the scrubber is the scrubbed text. Sources yield
+    raw text; the indexer scrubs once at entry, then hashes the
+    scrubbed form, embeds the scrubbed form, and stores the scrubbed
+    form. Raw text never leaves the indexer's process boundary.
+    Two raw commands that scrub to the same scrubbed text dedup to
+    one row — arguably correct semantics (same intent post-scrub).
+
+ARCHITECTURAL SEAM (CLAUDE.md "Architectural seams")
+
+    source (streaming) → indexer (chunks) → embedder (batches) → DB write (per-batch)
+
+    Sources stream via iter_entries — never materialized via
+    list(...) which would defeat the streaming advantage. The indexer
+    chunks streaming output into INDEXER_BATCH_ROWS-sized buffers,
+    sends each buffer to the embedder (whose internal batch_size is
+    a separate, smaller knob), and commits each buffer as one DB
+    transaction. Memory bounded by INDEXER_BATCH_ROWS.
+
+INCREMENTAL CURSOR (LOCKED Q2)
+
+    Per-source ts cursor in meta (key ``cursor_<source>``). Each
+    source's iter_entries(since=cursor) resumes after the last
+    indexed entry. The cursor advances atomically with the row
+    inserts it represents (within the same transaction). On crash
+    mid-batch, the cursor stays at the last successfully committed
+    batch's max ts — restart re-processes only those entries that
+    weren't committed.
+
+REBUILD SEMANTICS (LOCKED Q5, CLAUDE.md §4b)
+
+    --rebuild: DROP + CREATE commands + commands_vec + commands_fts
+        (the well-tested vec0 reset path; salt preserved).
+    --rebuild --new-salt: rotates salt then rebuilds.
+    --new-salt without --rebuild: rejected by the CLI (the salt and
+        rows must agree on hash provenance).
+
+    Cursor metas are also reset on --rebuild — re-indexing from
+    scratch starts cursors at zero so all entries are processed.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+import time
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+
+from recall.db import (
+    dedup_hash,
+    dedup_salt,
+    get_cursor,
+    set_cursor,
+    set_meta,
+    transaction,
+)
+from recall.embed import Embedder
+from recall.scrub import scrub
+from recall.sources.base import Entry, HistorySource
+
+_LOG = logging.getLogger(__name__)
+
+# Indexer-batch size — how many entries we buffer between DB transactions.
+# Locked at 1024 per Q4: the embedder's internal batch_size (default 64)
+# handles GPU/CPU memory throughput; the indexer batch handles transaction
+# amortization. Memory: 1024 × 384 × 4 = 1.5 MB per buffer.
+INDEXER_BATCH_ROWS = 1024
+
+# Progress-line cadence (seconds). Per Q7: periodic stderr line, no tqdm.
+PROGRESS_INTERVAL_S = 2.5
+
+
+@dataclass
+class IndexResult:
+    """Summary of one ``index_sources`` invocation."""
+
+    inserted: int = 0
+    skipped_dedup: int = 0  # row already present (UNIQUE conflict)
+    skipped_scrub_only: int = 0  # entry's scrubbed text matched an existing hash
+    by_source: dict[str, int] = field(default_factory=dict)
+    runtime_seconds: float = 0.0
+    embedder_seconds: float = 0.0
+    db_write_seconds: float = 0.0
+
+    def total_processed(self) -> int:
+        return self.inserted + self.skipped_dedup + self.skipped_scrub_only
+
+
+def _drop_and_create(conn: sqlite3.Connection) -> None:
+    """Rebuild path: drop and re-create commands + commands_vec + commands_fts.
+
+    sqlite-vec's vec0 virtual table is well-tested on CREATE-from-scratch
+    but historically not on DELETE FROM (locked Q5). DROP + CREATE is the
+    unambiguous reset. Salt and other meta keys are preserved across this
+    operation — only the row stores reset.
+
+    The FTS5 sync triggers reference both ``commands`` and ``commands_fts``,
+    so they're dropped first. Recreated from migrations/0001_initial.sql.
+    """
+    from importlib.resources import files
+
+    # Order matters: drop triggers (which reference commands + commands_fts)
+    # before dropping their target tables. Then drop indices; then drop the
+    # FTS and vec virtual tables; then drop commands. Finally, re-run the
+    # original schema's CREATE statements (filtered to only the parts we
+    # dropped — meta stays intact).
+    drop_sql = """
+        DROP TRIGGER IF EXISTS commands_ai;
+        DROP TRIGGER IF EXISTS commands_ad;
+        DROP TRIGGER IF EXISTS commands_au;
+        DROP TABLE   IF EXISTS commands_fts;
+        DROP TABLE   IF EXISTS commands_vec;
+        DROP INDEX   IF EXISTS idx_commands_session;
+        DROP INDEX   IF EXISTS idx_commands_cwd;
+        DROP INDEX   IF EXISTS idx_commands_ts;
+        DROP TABLE   IF EXISTS commands;
+    """
+    conn.executescript(drop_sql)
+
+    # Pull the original migration text and re-execute only the row-store
+    # CREATE block (everything except CREATE TABLE meta and the meta seed).
+    full = (files("recall.migrations") / "0001_initial.sql").read_text(encoding="utf-8")
+    # Heuristic: skip lines that are part of the meta CREATE/INSERT block
+    # and execute the rest. The migration file's structure is stable
+    # (CLAUDE.md §1.3 — never edit post-release) so this string match is safe.
+    create_block = full[full.index("CREATE TABLE commands") :]
+    conn.executescript(create_block)
+
+    # Reset cursor metas — fresh rebuild means all sources re-index from zero.
+    # Use a SELECT then DELETE pattern so we touch only cursor keys.
+    keys = [
+        row["key"]
+        for row in conn.execute("SELECT key FROM meta WHERE key LIKE 'cursor_%'").fetchall()
+    ]
+    for k in keys:
+        conn.execute("DELETE FROM meta WHERE key = ?", (k,))
+
+
+def rebuild(conn: sqlite3.Connection) -> None:
+    """Public entry point for the --rebuild path.
+
+    Does NOT wrap _drop_and_create in transaction() — _drop_and_create
+    uses ``executescript()``, which issues an implicit COMMIT before
+    running, leaving no transaction for the wrapper to commit (CLAUDE.md
+    "Composition is where bugs live", instance #2 — the exact same trap
+    1.3's migrate() fell into). SQLite DDL is durable per-statement; the
+    sequence of DROP/CREATE statements is robust against mid-rebuild
+    interruption (next rebuild() finds whatever subset of tables exist
+    and DROPs IF EXISTS).
+
+    Caller (the CLI) is responsible for calling rotate_dedup_salt before
+    rebuild() if --new-salt was also requested. See CLAUDE.md §4b.
+    """
+    _drop_and_create(conn)
+    _LOG.info("recall.indexer: rebuilt commands/commands_vec/commands_fts; cursors cleared")
+
+
+def _process_batch(
+    conn: sqlite3.Connection,
+    batch: list[Entry],
+    embedder: Embedder,
+    salt: bytes,
+    timing: IndexResult,
+) -> tuple[int, int]:
+    """Scrub, hash, dedup, embed, and write one batch.
+
+    Returns ``(inserted, skipped)``. The caller advances cursors based
+    on the batch's max-ts AFTER this returns successfully.
+
+    ARCHITECTURAL INVARIANT: scrubbing happens FIRST. The hash and the
+    embedding both consume the scrubbed text. Two raw entries that
+    scrub to the same text collapse to a single hash; the second
+    insert hits the UNIQUE constraint and is reported as a dedup
+    skip.
+    """
+    if not batch:
+        return 0, 0
+
+    # Step 1: scrub each entry's raw text. This is where raw text dies.
+    scrubbed_texts: list[str] = [scrub(e.text) for e in batch]
+
+    # Step 2: compute hash over scrubbed text. Salt is the current
+    # meta.dedup_salt at indexer construction time.
+    hashes: list[bytes] = [dedup_hash(salt, t) for t in scrubbed_texts]
+
+    # Step 3: pre-dedup against the DB so we don't waste embedder
+    # cycles on rows that will hit UNIQUE conflicts. Query existing
+    # (source, text_hash, ts) triples for the batch's hashes.
+    # SQLite has a 999-parameter default limit; we'd need 3 × 1024 =
+    # 3072 to query all keys at once via IN clause. Chunk to be safe.
+    keys_to_check = [(e.source, h, e.ts) for e, h in zip(batch, hashes, strict=True)]
+    existing: set[tuple[str, bytes, int]] = set()
+    for chunk_start in range(0, len(keys_to_check), 200):
+        chunk = keys_to_check[chunk_start : chunk_start + 200]
+        params: list[object] = []
+        for s, h, t in chunk:
+            params.extend([s, h, t])
+        # SQLite doesn't support row-value IN with mixed-type tuples
+        # cleanly, so fall back to a per-chunk SELECT with OR.
+        where = " OR ".join(["(source = ? AND text_hash = ? AND ts = ?)"] * len(chunk))
+        rows = conn.execute(
+            f"SELECT source, text_hash, ts FROM commands WHERE {where}",
+            params,
+        ).fetchall()
+        for r in rows:
+            existing.add((str(r["source"]), bytes(r["text_hash"]), int(r["ts"])))
+
+    # Step 4: filter the batch to cache-misses only. These get embedded.
+    miss_indices: list[int] = []
+    for i, (e, h) in enumerate(zip(batch, hashes, strict=True)):
+        if (e.source, h, e.ts) in existing:
+            continue
+        miss_indices.append(i)
+
+    skipped = len(batch) - len(miss_indices)
+
+    if not miss_indices:
+        return 0, skipped
+
+    # Step 5: embed cache-miss scrubbed texts. The embedder handles
+    # internal batching at its own batch_size; we just hand it the
+    # full miss list.
+    miss_texts = [scrubbed_texts[i] for i in miss_indices]
+    t0 = time.perf_counter()
+    miss_vectors = embedder.encode(miss_texts)
+    timing.embedder_seconds += time.perf_counter() - t0
+
+    # Step 6: write to DB in one transaction. INSERT into commands +
+    # INSERT into commands_vec for each miss. Cursor advance happens
+    # in the caller AFTER this commits successfully.
+    t0 = time.perf_counter()
+    with transaction(conn):
+        inserted = 0
+        for j, idx in enumerate(miss_indices):
+            entry = batch[idx]
+            scrubbed = scrubbed_texts[idx]
+            h = hashes[idx]
+            vec = miss_vectors[j]
+            try:
+                cur = conn.execute(
+                    """
+                    INSERT INTO commands (
+                        source, source_id, text_scrubbed, text_hash,
+                        cwd, hostname, exit_code, duration_ms, session_id, ts
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        entry.source,
+                        entry.source_id,
+                        scrubbed,
+                        h,
+                        entry.cwd,
+                        entry.hostname,
+                        entry.exit_code,
+                        entry.duration_ms,
+                        entry.session_id,
+                        entry.ts,
+                    ),
+                )
+                command_id = cur.lastrowid
+                conn.execute(
+                    "INSERT INTO commands_vec (command_id, embedding) VALUES (?, ?)",
+                    (command_id, vec.tobytes()),
+                )
+                inserted += 1
+            except sqlite3.IntegrityError:
+                # Race with a parallel pre-dedup miss (shouldn't happen
+                # in our sequential indexer; defensive).
+                skipped += 1
+    timing.db_write_seconds += time.perf_counter() - t0
+
+    return inserted, skipped
+
+
+def _stream_with_cursor(
+    source: HistorySource,
+    conn: sqlite3.Connection,
+) -> Iterator[Entry]:
+    """Yield entries from ``source`` starting after that source's cursor.
+
+    Cursor is read from ``meta.cursor_<source.name>`` (None == start
+    from the beginning).
+    """
+    cursor = get_cursor(conn, source.name)
+    yield from source.iter_entries(since=cursor)
+
+
+def index_sources(
+    conn: sqlite3.Connection,
+    sources: Sequence[HistorySource],
+    embedder: Embedder | None = None,
+    *,
+    progress: bool = True,
+) -> IndexResult:
+    """Run one indexing pass over ``sources``, sequentially (Q3 lock).
+
+    Each source is fully drained before the next starts. Within a source,
+    entries are buffered into INDEXER_BATCH_ROWS-size batches; each batch
+    triggers one embedder.encode() call and one DB transaction. Cursor
+    advances after each successful batch commit, so a crash mid-source
+    leaves the cursor at the last committed batch's max ts.
+
+    Per Q3: sequential (not parallel) because the embedder is already
+    batched internally — threading the orchestration adds GIL contention
+    without real parallelism.
+
+    Per Q7: progress is a periodic stderr line (every PROGRESS_INTERVAL_S
+    seconds), not tqdm. ``progress=False`` disables it entirely (used
+    by tests).
+    """
+    if embedder is None:
+        embedder = Embedder()
+
+    salt = dedup_salt(conn)
+    result = IndexResult()
+    overall_start = time.perf_counter()
+    last_progress = overall_start
+
+    def _flush(
+        batch: list[Entry],
+        max_ts: int,
+        source_name: str,
+    ) -> tuple[int, int]:
+        # Module-scope-style flush: takes source_name explicitly to avoid
+        # closure-over-loop-variable late-binding (B023). The result and
+        # salt and embedder come from the enclosing index_sources scope,
+        # which is fixed across the call.
+        ins, skip = _process_batch(conn, batch, embedder, salt, result)
+        if max_ts > 0:
+            # Advance cursor only when a batch had a known timestamp.
+            # Entries with ts=0 (unknown) leave the cursor untouched.
+            with transaction(conn):
+                set_cursor(conn, source_name, max_ts)
+        return ins, skip
+
+    for source in sources:
+        source_inserted = 0
+        batch: list[Entry] = []
+        max_ts_in_batch = 0
+
+        for entry in _stream_with_cursor(source, conn):
+            batch.append(entry)
+            if entry.ts > max_ts_in_batch:
+                max_ts_in_batch = entry.ts
+            if len(batch) >= INDEXER_BATCH_ROWS:
+                ins, skip = _flush(batch, max_ts_in_batch, source.name)
+                source_inserted += ins
+                result.inserted += ins
+                result.skipped_dedup += skip
+                batch = []
+                max_ts_in_batch = 0
+
+                # Periodic progress line.
+                now = time.perf_counter()
+                if progress and (now - last_progress) >= PROGRESS_INTERVAL_S:
+                    elapsed = now - overall_start
+                    print(
+                        f"recall index: {source.name} +{source_inserted} (~{elapsed:.0f}s elapsed)",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    last_progress = now
+
+        # Flush trailing partial batch.
+        if batch:
+            ins, skip = _flush(batch, max_ts_in_batch, source.name)
+            source_inserted += ins
+            result.inserted += ins
+            result.skipped_dedup += skip
+
+        result.by_source[source.name] = source_inserted
+        if progress:
+            elapsed = time.perf_counter() - overall_start
+            print(
+                f"recall index: {source.name} done +{source_inserted} (~{elapsed:.0f}s elapsed)",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    # Stamp the embedder model into meta so we can detect mismatches at
+    # query time (CLAUDE.md §4 "Embedding consistency"). Idempotent.
+    set_meta(conn, "embedding_model_name", embedder.model_name)
+    set_meta(conn, "embedding_model_revision", embedder.model_revision or "")
+
+    result.runtime_seconds = time.perf_counter() - overall_start
+    return result
+
+
+__all__ = (
+    "INDEXER_BATCH_ROWS",
+    "IndexResult",
+    "index_sources",
+    "rebuild",
+)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,309 @@
+"""Integration tests for the indexer (Commit 2.8).
+
+The indexer is consumer-less until Phase 3's MCP server lands — there is
+no public ``recall search`` yet. These tests verify the DB-layer write
+path directly: rows land in ``commands``, vectors land in ``commands_vec``,
+the dedup constraint holds, the rebuild path drops + recreates correctly,
+the per-source cursor advances, and (critically per Q8) the scrubber's
+write-path integration leaves zero matches against any of the 18
+scrubber-pattern types in ``commands.text_scrubbed``.
+
+All tests use a stub Embedder that produces deterministic vectors per
+text — no model load, fast lane. End-to-end semantic correctness is
+already covered by the eval-lane tests on the SemanticRanker side.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from collections.abc import Iterator, Sequence
+
+import numpy as np
+import pytest
+
+from recall.db import (
+    connect,
+    dedup_salt,
+    get_cursor,
+    get_meta,
+    migrate,
+    rotate_dedup_salt,
+)
+from recall.indexer import index_sources, rebuild
+from recall.sources.base import Entry
+
+
+class _FakeEmbedder384:
+    """Deterministic in-memory embedder satisfying Embedder's duck-typed
+    surface, producing dim=384 vectors to match the on-disk schema's
+    ``commands_vec.embedding FLOAT[384]``. SHA-256 of text → 16 bytes →
+    repeated to 384 floats, centered + L2-normalized. No model load."""
+
+    model_name = "fake-embedder/v0"
+    model_revision = None
+    dim = 384
+
+    def encode(self, texts: Sequence[str]) -> np.ndarray:
+        out = np.zeros((len(texts), self.dim), dtype=np.float32)
+        for i, t in enumerate(texts):
+            digest = hashlib.sha256(t.encode("utf-8")).digest()
+            small = np.frombuffer(digest[:16], dtype=np.uint8).astype(np.float32)
+            small -= 128.0
+            tiled = np.tile(small, 24).astype(np.float32)  # 16 * 24 = 384
+            n = float(np.linalg.norm(tiled))
+            out[i] = tiled / (n if n > 0 else 1.0)
+        return out
+
+
+class _StubSource:
+    """A HistorySource that yields pre-defined entries; honors ``since`` so
+    cursor tests can exercise incremental behavior."""
+
+    def __init__(self, name: str, entries: list[Entry]) -> None:
+        self.name = name
+        self._entries = entries
+
+    def iter_entries(self, since: int | None = None) -> Iterator[Entry]:
+        for e in self._entries:
+            if e.ts == 0 or since is None or e.ts > since:
+                yield e
+
+
+@pytest.fixture
+def conn(tmp_path) -> sqlite3.Connection:
+    """Per-test fresh DB at tmp_path/db.sqlite, migrated to v1."""
+    db_path = tmp_path / "db.sqlite"
+    c = connect(db_path)
+    migrate(c)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def real_dim_embedder() -> _FakeEmbedder384:
+    return _FakeEmbedder384()
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+# === 1. Basic round-trip ===
+
+
+def test_index_inserts_rows_and_vectors(conn, real_dim_embedder) -> None:
+    """Single source, three entries → three rows in commands + commands_vec."""
+    src = _StubSource(
+        "zsh",
+        [
+            Entry(text="ls -la", ts=100, source="zsh"),
+            Entry(text="git status", ts=200, source="zsh"),
+            Entry(text="cd /tmp", ts=300, source="zsh"),
+        ],
+    )
+    result = index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+
+    assert result.inserted == 3
+    assert result.skipped_dedup == 0
+    assert _row_count(conn, "commands") == 3
+    assert _row_count(conn, "commands_vec") == 3
+    # Cursor advanced to max ts in the batch.
+    assert get_cursor(conn, "zsh") == 300
+
+
+# === 2. Incremental: re-indexing yields no new rows ===
+
+
+def test_reindex_with_no_new_entries_inserts_nothing(conn, real_dim_embedder) -> None:
+    src = _StubSource(
+        "zsh",
+        [
+            Entry(text="cmd one", ts=100, source="zsh"),
+            Entry(text="cmd two", ts=200, source="zsh"),
+        ],
+    )
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 2
+
+    # Re-run: cursor now at 200, source's iter_entries(since=200) yields nothing.
+    result2 = index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert result2.inserted == 0
+    assert _row_count(conn, "commands") == 2
+
+
+# === 3. Rebuild clears + refills, salt preserved ===
+
+
+def test_rebuild_clears_and_refills_preserving_salt(conn, real_dim_embedder) -> None:
+    src = _StubSource(
+        "zsh",
+        [Entry(text=f"cmd {i}", ts=100 + i, source="zsh") for i in range(5)],
+    )
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 5
+
+    salt_before = dedup_salt(conn)
+    salt_version_before = get_meta(conn, "dedup_salt_version")
+
+    rebuild(conn)
+    assert _row_count(conn, "commands") == 0
+    assert _row_count(conn, "commands_vec") == 0
+    # Cursor was reset.
+    assert get_cursor(conn, "zsh") is None
+    # Salt preserved.
+    assert dedup_salt(conn) == salt_before
+    assert get_meta(conn, "dedup_salt_version") == salt_version_before
+
+    # Re-index: rows come back.
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 5
+
+
+# === 4. New-salt rebuild changes the hash space ===
+
+
+def test_new_salt_rebuild_changes_hashes(conn, real_dim_embedder) -> None:
+    src = _StubSource(
+        "zsh",
+        [Entry(text="echo hello", ts=100, source="zsh")],
+    )
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    hash_before = bytes(conn.execute("SELECT text_hash FROM commands").fetchone()[0])
+
+    # Rotate salt + rebuild + re-index: same raw text → different hash.
+    rotate_dedup_salt(conn)
+    rebuild(conn)
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    hash_after = bytes(conn.execute("SELECT text_hash FROM commands").fetchone()[0])
+
+    assert hash_before != hash_after, "salt rotation must change the hash"
+
+
+# === 5. Multi-source dedup via UNIQUE(source, text_hash, ts) ===
+
+
+def test_same_command_in_two_sources_creates_two_rows(conn, real_dim_embedder) -> None:
+    """zsh and bash both record 'ls -la' at ts=100 — UNIQUE allows both
+    because (source, text_hash, ts) differs in source."""
+    zsh = _StubSource("zsh", [Entry(text="ls -la", ts=100, source="zsh")])
+    bash = _StubSource("bash", [Entry(text="ls -la", ts=100, source="bash")])
+    index_sources(conn, [zsh, bash], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 2
+
+
+def test_same_command_same_source_same_ts_dedups(conn, real_dim_embedder) -> None:
+    """Two passes of the same source yielding the same entry: row inserted
+    once via the indexer's pre-dedup check (UNIQUE constraint backstops)."""
+    src = _StubSource("zsh", [Entry(text="ls -la", ts=100, source="zsh")])
+    # First pass: cursor was None, entry yielded, inserted.
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 1
+
+    # Second pass: cursor = 100. The stub source skips entries with ts <= since,
+    # so it yields nothing; row count unchanged.
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    assert _row_count(conn, "commands") == 1
+
+
+# === 6. Scrubber integration: secret indexes scrubbed ===
+
+
+def test_scrubber_redacts_secret_in_indexed_text(conn, real_dim_embedder) -> None:
+    src = _StubSource(
+        "zsh",
+        [
+            Entry(
+                text="export GITHUB_TOKEN=ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE",
+                ts=100,
+                source="zsh",
+            ),
+        ],
+    )
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+    rows = conn.execute("SELECT text_scrubbed FROM commands").fetchall()
+    assert len(rows) == 1
+    scrubbed = rows[0]["text_scrubbed"]
+    assert "ghp_FAKEFAKE" not in scrubbed, "raw GitHub token leaked into commands.text_scrubbed"
+    assert "<REDACTED:" in scrubbed
+
+
+# === 7. Adversarial scrubber-integration test (per Q8 refinement) ===
+
+
+def test_adversarial_scrubber_corpus_no_pattern_matches_in_db(conn, real_dim_embedder) -> None:
+    """Index every line of tests/fixtures/secrets_corpus.txt; assert the
+    resulting commands.text_scrubbed contains zero matches against any of
+    the scrubber's 18 known secret-pattern types.
+
+    This closes the loop between scrubber coverage and indexer write
+    path. The scrubber's own canary tests verify scrub(line) is clean
+    in isolation; this test verifies the indexer doesn't somehow let a
+    pre-scrubber raw line through into the DB.
+    """
+    from pathlib import Path
+
+    fixture = Path(__file__).parent / "fixtures" / "secrets_corpus.txt"
+    lines = [
+        ln.strip()
+        for ln in fixture.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and not ln.startswith("#")
+    ]
+    assert len(lines) >= 30, "fixture shrank; expected ≥30 secret-bearing lines"
+
+    src = _StubSource(
+        "zsh",
+        [Entry(text=ln, ts=1000 + i, source="zsh") for i, ln in enumerate(lines)],
+    )
+    index_sources(conn, [src], embedder=real_dim_embedder, progress=False)
+
+    rows = conn.execute("SELECT text_scrubbed FROM commands").fetchall()
+    indexed_texts = [r["text_scrubbed"] for r in rows]
+    combined = "\n".join(indexed_texts)
+
+    # Sentinel check: the canonical FAKEFAKE token in raw inputs should
+    # have been replaced by <REDACTED:*> markers. If FAKEFAKE shows up
+    # in indexed output, a secret leaked through.
+    if "FAKEFAKE" in combined:
+        # Find the leaking lines so the failure is debuggable.
+        offenders = [t for t in indexed_texts if "FAKEFAKE" in t]
+        pytest.fail(
+            f"adversarial: {len(offenders)} indexed line(s) still contain "
+            f"FAKEFAKE (secret leak through indexer). Sample: {offenders[:3]!r}"
+        )
+
+    # Also assert against each of the high-signal scrubber patterns
+    # explicitly. These mirror the canary in tests/test_scrub.py and
+    # catch regressions where scrub() got bypassed in the indexer.
+    pattern_signatures: list[tuple[str, str]] = [
+        ("AWS access key", r"AKIA[0-9A-Z]{16}"),
+        ("AWS secret-key kwarg", r"aws_secret_access_key\s*=\s*[A-Za-z0-9/+=]{20,}"),
+        ("GitHub token (ghp_)", r"\bghp_[A-Za-z0-9]{30,}"),
+        ("GitHub token (gho_)", r"\bgho_[A-Za-z0-9]{30,}"),
+        ("GitHub token (ghs_)", r"\bghs_[A-Za-z0-9]{30,}"),
+        ("GitHub token (ghu_)", r"\bghu_[A-Za-z0-9]{30,}"),
+        ("GitHub PAT", r"\bgithub_pat_[A-Za-z0-9_]{30,}"),
+        ("OpenAI key", r"\bsk-[A-Za-z0-9]{30,}"),
+        ("Slack token", r"\bxox[baprs]-[A-Za-z0-9-]{10,}"),
+        ("Google API key", r"\bAIzaSy[A-Za-z0-9_-]{30,}"),
+        ("URL userinfo (with secret)", r"://[^:/<>\s]+:[^@/<>\s]{6,}@"),
+        ("PGPASSWORD env", r"\bPGPASSWORD\s*=\s*[^\s<]{4,}"),
+        ("MYSQL_PWD env", r"\bMYSQL_PWD\s*=\s*[^\s<]{4,}"),
+        ("--password flag value", r"--password(?:[ =])[^\s<]{4,}"),
+        ("mysql -p<value>", r"\bmysql\s+-p[^\s<]{4,}"),
+        ("X-API-Key header", r"X-API-Key:\s*[A-Za-z0-9._-]{16,}"),
+        ("X-Auth-Token header", r"X-Auth-Token:\s*[A-Za-z0-9._-]{16,}"),
+        ("Bearer token", r"Bearer\s+eyJ[A-Za-z0-9._-]{20,}"),
+    ]
+    for name, pat in pattern_signatures:
+        matches = re.findall(pat, combined)
+        # The patterns above match secret-shaped strings. Some can still
+        # match the <REDACTED:KIND> marker text (e.g. "URL userinfo"
+        # might fire if the pattern is too loose). Filter out matches
+        # that are entirely composed of redaction markers.
+        real_matches = [m for m in matches if "<REDACTED:" not in m]
+        assert not real_matches, (
+            f"adversarial: scrubber missed {name!r} in indexer write path. "
+            f"Matches: {real_matches[:3]!r}"
+        )


### PR DESCRIPTION
## Summary

- Phase 2 indexer: `HistorySource` → scrubber → embedder → DB write
- Eight locked Q-decisions executed (scrub-then-hash; per-source cursor; sequential multi-source; 1024-row batches; DROP+CREATE rebuild; M-series ≤60s gate; periodic-stderr progress; integration tests with adversarial scrubber check)
- M-series 50k-perf gate: 42.55s ≤ 60s (~17s headroom)
- Re-stepped composition bug #2 (executescript-vs-transaction) caught + fixed locally before push; inline comment names the trap

## Verification (local M-series, post-rebase onto hotfix main)

- ruff + ruff format + mypy — green
- pytest -m "not embed" — 217 passed (+8 indexer integration tests)
- synthetic 50k-perf gate: 42.55s
- adversarial scrubber-corpus integration test: passes (zero pattern matches against 18 scrubber types in `commands.text_scrubbed`)

## Test plan

- [ ] Linux embed lane: behavior-preservation + equivalence still pass post-rebase
- [ ] Linux all-rankers cumulative under 660s budget (post-hotfix ceiling)
- [ ] All 7 fast-lane matrix jobs pass
- [ ] scrub-canary skips correctly (scrub.py untouched in 2.8)
- [ ] regression gate: nl2bash aggregate within ±0.01; dogfood per-query unchanged

## Decision tree post-CI

- All green → surface canonical squash-merge plan for user approval (local `git merge --squash`, NOT `gh pr merge`)
- Any failure → stop and surface

## Files

| File | Status | LoC |
|---|---|---:|
| `src/recall/indexer.py` | new | ~280 |
| `src/recall/cli.py` | modify (`index` stub → real) | ~80 |
| `src/recall/db.py` | modify (cursor helpers) | ~30 |
| `tests/test_indexer.py` | new (8 integration tests) | ~280 |
| `CLAUDE.md` | modify (cursor schema, perf cross-ref, eval-vs-production seam, 2.9 sequencing flag, build order) | ~40 |

No new dependencies. No CI workflow changes. Indexer is consumer-less until Phase 3's `recall search` lands; integration tests verify the DB-layer write path directly.
