### PR TITLE
test(stdio): cleanliness CI lane (Commit 3.11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # 3.11: daily stdio-cleanliness run at 06:00 UTC. Catches upstream
+    # library regressions silently introducing stdout writes (e.g. a
+    # sentence-transformers update adds a progress bar). Lowest GitHub
+    # Actions queue contention. Only the `stdio` job runs on schedule;
+    # the others gate on `github.event_name != 'schedule'`.
+    - cron: '0 6 * * *'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -13,6 +20,7 @@ jobs:
   fast:
     name: fast (${{ matrix.os }} / py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +47,7 @@ jobs:
   embed:
     name: embed (ubuntu / py3.12)
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +80,11 @@ jobs:
         # symptom for now.
         env:
           RECALL_EVAL_HARD_FAIL_S: "360"
-        run: uv run --python 3.12 pytest -m embed
+        # --ignore the stdio-cleanliness file: the cold-cache test in
+        # there is @pytest.mark.embed but is owned by the dedicated
+        # `stdio` lane (3.11). Running it here would double the
+        # ~25s cold-cache cost without gating on anything new.
+        run: uv run --python 3.12 pytest -m embed --ignore=tests/test_stdio_cleanliness.py
       - name: recall eval (nl2bash + dogfood)
         # GitHub-hosted Linux is ~7x slower than M-series Mac for embedding
         # work (CPU vs MPS). Two separate budgets: per-ranker hard fail
@@ -100,6 +113,38 @@ jobs:
       - name: regression gate (PR only)
         if: github.event_name == 'pull_request'
         run: uv run --python 3.12 python .github/scripts/check_eval_regression.py /tmp/ci_eval.json
+
+  stdio:
+    name: stdio (ubuntu / py3.12)
+    runs-on: ubuntu-latest
+    # 3.11 dedicated lane: subprocess + cold-cache stress + AST + T201
+    # invocation. Per CLAUDE.md §5 + the F2 lock at 3.11 plan:
+    #  - stdio cleanliness invariant lives here
+    #  - Linux-only for v1; M-series cleanliness verified via maintainer
+    #    manual smoke (tests/manual_smoke.md Section D)
+    #  - daily schedule trigger catches upstream regressions (e.g. HF
+    #    adds progress bar in a future release silently)
+    #
+    # Runtime envelope: ~30s (cold-cache pays ~25s for HF download +
+    # model load on Linux CPU; AST/T201 ≈ <1s; subprocess scaffolding
+    # ≈ ~5s). If lane runtime grows past 90s, investigate (see
+    # CLAUDE.md "Performance budgets").
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: install python 3.12
+        run: uv python install 3.12
+      - name: sync deps
+        run: uv sync --python 3.12
+      - name: stdio cleanliness suite (subprocess + AST + T201)
+        # PYTHONUNBUFFERED ensures stdout writes from the subprocess
+        # under test are flushed to the parent without buffering — we
+        # need byte-for-byte determinism on what reaches stdout.
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: uv run --python 3.12 pytest tests/test_stdio_cleanliness.py -v
 
   scrub-canary:
     name: scrubber test count canary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,70 @@ correctly draining what it sees; the bug is in the static-pipe
 test harness's premise that stdin can EOF immediately and frames
 will still be processed.
 
+**stdio-cleanliness CI lane (3.11).** A dedicated `stdio` lane runs
+on every PR + main push + daily 06:00 UTC, exercising:
+- subprocess test A: initialize-only round-trip (cleanliness w/o tool dispatch)
+- subprocess test C: tools/call recent against empty DB (dispatch isolation)
+- subprocess test D: cold-cache tools/call search (the marquee test —
+  forces fresh HF model download via empty `HF_HOME`, asserts no
+  library progress bars or load messages leak to stdout; ~25s on
+  Linux CPU)
+- subprocess test E: lazy-refresh transition end-to-end (subprocess
+  wiring of the 3.10 first-run UX fix)
+- AST check: rejects `sys.stdout.write` / `os.write(1, ...)` /
+  `StreamHandler(sys.stdout)` / `print(..., file=sys.stdout)` anywhere
+  in `src/recall/`
+- ruff T201 invocation as test (belt-and-suspenders against bypassed
+  per-file ignores)
+
+The reusable subprocess fixture lives in `tests/conftest.py` as
+`mcp_subprocess_session` (and the parametrized factory variant
+`mcp_subprocess_factory`). Holds stdin open across the whole session
+— this is what the 3.10 static-pipe-EOF finding above prescribed.
+3.12's pseudo-client + recorded-session-fixture replay tests inherit
+the helper API (initialize / list_tools / call_tool / close /
+stderr_text) without modification.
+
+**Linux-only for v1.** Per F2 lock at 3.11 plan: stdio-cleanliness CI
+runs on Linux py3.12 only. M-series-specific cleanliness (MPS warmup
+prints, mac-specific torch warnings) is verified via maintainer's
+local manual smoke pre-launch. v1.x may add cross-platform CI when
+self-hosted M-series runners are available. **v1.0 launch checklist
+item (must be complete before announce):** run cold-cache subprocess
+test on local M-series Mac, append result to docs/clients-tested.md.
+
+**Daily CI failure recovery path (v1).** Workflow-run failure only —
+GitHub Actions' default failure email to the repo owner is sufficient
+for one-maintainer triage. Recovery rule: if cold-cache test fails on
+a daily run with network/timeout error, re-run once. Twice consecutive
+= real signal (check status.huggingface.co or treat as regression).
+Don't pre-emptively `@pytest.mark.flaky(reruns=2)` — masks signal.
+Manual maintainer decision based on observed failure pattern, not
+automatic CI rule. Phase 4 may add user-facing alerting (status badge
+in README) but v1 gate-existence is the value.
+
+**T201 + AST-check split, validated at 3.11 implementation.** During
+3.11 first-run, T201 caught two `print(..., file=sys.stderr)` calls
+in `src/recall/indexer.py` (CLI command, not on the stdio path).
+They were SAFE (explicit stderr destination), but T201 doesn't
+differentiate. Resolution: per-file-ignore for `indexer.py` in
+`pyproject.toml` with a documented rationale comment. The split
+of three rules — T201 (blanket "no print"), the AST check (precise
+"no stdout writes"), per-file-ignores (narrow exceptions where the
+blanket overshoots) — is doing the work intended:
+  - **T201** catches everything that *might* leak (false positives
+    are intentional; we'd rather force a justification than miss
+    a leak)
+  - **AST check** catches the actual leak vectors (`sys.stdout.write`,
+    `os.write(1, …)`, `StreamHandler(sys.stdout)`,
+    `print(…, file=sys.stdout)`) regardless of whether T201 fired
+  - **Per-file-ignores** narrow scope where the blanket rule provably
+    overshoots — `tests/`, `.github/scripts/`, `src/recall/indexer.py`
+A future contributor hitting T201 friction in non-stdio code should
+follow the same pattern: confirm via the AST check that the file
+isn't on a stdio path, then add a per-file-ignore with a comment
+linking back to this CLAUDE.md section.
+
 ### 6. Performance budgets (CI-enforced, Phase 3+)
 
 - Cold start (model load + db open): < 2 s on M-series Mac
@@ -408,6 +472,13 @@ will still be processed.
   itself, not just CI) at 120 s. The hard fail makes the runtime gate live
   in the harness, so an accidental 10× slowdown trips the discipline before
   CI even sees it.
+- stdio lane (Ubuntu py3.12; 3.11): ~30 s expected. Cold-cache
+  subprocess test pays HF model download + load ≈ 20-25 s; AST/T201
+  ≈ <1 s; subprocess scaffolding ≈ ~5 s. If lane runtime grows past
+  90 s, investigate — likely a new test, a model-download regression,
+  or a cache-isolation bug. Cold-cache test has a 90 s per-call
+  timeout with a diagnosable failure message that distinguishes
+  "HF download exceeded budget" from "stdout pollution."
 
 **Platform-translation factor (CI vs M-series).** CI Linux is
 **~11× slower than M-series Mac** for encode-bound workloads, not the
@@ -1226,6 +1297,30 @@ don't get lost in chat history.
   proves regression prevention, the real-history audit proves
   real-world coverage. Land in the README's privacy / trust
   section at v1 launch. Tag: documentation, phase-4.
+- **M-series stdio-cleanliness CI** — v1.x post-launch. Requires
+  self-hosted M-series runner (or GitHub-hosted ARM macOS runners
+  reaching general availability). Target the same cold-cache
+  subprocess test that runs on Linux today. Tag: tech-debt, ci,
+  post-v1.
+- **Status badge for stdio-cleanliness lane** — Phase 4 README
+  content. Add CI badge to README so HN visitors can see the
+  invariant is enforced (the trust story). Tag: documentation,
+  phase-4.
+- **v1.0 launch checklist: cold-cache subprocess test on local
+  M-series Mac.** Run before announce; append result to
+  docs/clients-tested.md (lands in Commit 3.13). The Linux-only
+  CI gate is sufficient for catch-on-PR; M-series adds confidence
+  that MPS warmup messages don't leak. Tag: v1-launch-blocker,
+  must-do-before-announce.
+- **Refactor `src/recall/indexer.py` `print(..., file=sys.stderr)`
+  calls to use logging.** Phase 4 polish, low priority. Currently
+  the indexer's user-facing progress lines (during `recall index`
+  CLI runs) use `print` with a per-file-ignore in pyproject.toml's
+  T201 enforcement. Refactoring to `_LOG.info()` would be more
+  consistent with the rest of the codebase and remove the per-file
+  exception. Cosmetic — the indexer is not on the stdio path
+  (CLI command, not the MCP server), so the prints are safe today.
+  Tag: tech-debt, phase-4.
 - **NL paraphrase-distance validator for the eval harness** —
   Phase-2-or-later, eval-quality. Automated shared-token analysis
   between NL and command after FTS5 tokenization, output a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,11 +89,29 @@ select = [
   "UP",  # pyupgrade
   "SIM", # flake8-simplify
   "RUF", # ruff-specific
+  "T201", # 3.11: ban print() in stdio-bound code paths.
+          # Print silently breaks MCP framing (CLAUDE.md §5). Tests +
+          # CI scripts + the indexer CLI are not stdio-bound — see
+          # per-file-ignores below.
 ]
 # CLI summary uses U+00D7 (×) as the multiplier glyph in "semantic is N.NX×
 # better" output and U+221E (∞) for the divide-by-zero ranker case. Both
 # are intentional human-facing display chars, not confusables to flag.
 allowed-confusables = ["×", "∞"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests may print() for debugging — they're ephemeral, not under stdio
+# constraint. No test currently prints; the entry declares policy for
+# future contributors.
+"tests/**/*.py" = ["T201"]
+# CI helper scripts run in the GitHub Actions runner; not stdio-bound.
+".github/scripts/*.py" = ["T201"]
+# `recall index` is a CLI command run by the user; its stderr progress
+# lines are user-facing terminal output. Distinct from the MCP `recall
+# serve` stdio path. The custom AST check (test_stdio_cleanliness.py)
+# still rejects print(..., file=sys.stdout) here — only blanket T201
+# is relaxed.
+"src/recall/indexer.py" = ["T201"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
+import numpy as np
 import pytest
 
 from tests.fixtures.make_atuin_fixture import make_atuin_fixture
@@ -19,3 +30,393 @@ def atuin_fixture_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     path = tmp_path_factory.mktemp("atuin") / "history.db"
     make_atuin_fixture(path)
     return path
+
+
+# === MCP subprocess session helper (3.11) ===
+#
+# Spawns ``recall serve`` in a real subprocess, holds stdin open, sends MCP
+# JSON-RPC frames one at a time as line-delimited JSON, reads responses on
+# stdout, captures stderr to a tmpfile. Designed for reuse:
+#
+#   - 3.11 stdio-cleanliness tests use this directly.
+#   - 3.12's pseudo-client + recorded-session-fixture replay tests inherit
+#     the same helper API (initialize / list_tools / call_tool / close /
+#     stderr_text) without modification per the locked plan.
+#
+# If 3.12 needs API adjustments (recorded-session replay might want
+# generic ``send_request(method, params)`` for non-tool requests), surface
+# them explicitly during 3.12's planning round so we know whether 3.11's
+# tests need re-running against the new API or whether 3.12 inherits as-is.
+
+
+class MCPSubprocessSession:
+    """Async helper around ``recall serve`` running in a subprocess.
+
+    Uses line-delimited JSON over stdin/stdout, matching the MCP stdio
+    transport's wire format. Holds stdin open across all sends — this is
+    the fix for the 3.10 static-pipe-EOF finding (CLAUDE.md §5).
+    """
+
+    def __init__(self, proc: subprocess.Popen[bytes], stderr_path: Path) -> None:
+        self._proc = proc
+        self._stderr_path = stderr_path
+        self._next_id = 1
+        # Read responses asynchronously so concurrent send/recv doesn't
+        # deadlock on a slow server. asyncio's StreamReader doesn't wrap
+        # Popen.stdout cleanly; we use a small read-line helper instead.
+        assert proc.stdout is not None
+        assert proc.stdin is not None
+        self._stdout = proc.stdout
+        self._stdin = proc.stdin
+
+    async def _read_line(self, *, timeout: float = 30.0) -> bytes:
+        """Read one line from the subprocess's stdout. Times out.
+
+        Per-line read because MCP stdio framing is one JSON object per
+        line (no Content-Length headers like LSP's framed mode).
+        """
+        loop = asyncio.get_event_loop()
+        future = loop.run_in_executor(None, self._stdout.readline)
+        line = await asyncio.wait_for(future, timeout=timeout)
+        if not line:
+            # EOF — server died. Capture stderr for the failure message.
+            stderr = self.stderr_text()
+            raise RuntimeError(f"recall serve closed stdout unexpectedly. stderr:\n{stderr}")
+        return line
+
+    async def _send(self, frame: dict[str, Any]) -> None:
+        data = (json.dumps(frame) + "\n").encode("utf-8")
+        self._stdin.write(data)
+        self._stdin.flush()
+
+    async def initialize(self) -> dict[str, Any]:
+        """Send initialize, return parsed result dict."""
+        req_id = self._next_id
+        self._next_id += 1
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-subprocess", "version": "0.0.1"},
+                },
+            }
+        )
+        line = await self._read_line()
+        return json.loads(line)
+
+    async def notify_initialized(self) -> None:
+        """Send the initialized notification (no response expected)."""
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            }
+        )
+
+    async def list_tools(self) -> dict[str, Any]:
+        req_id = self._next_id
+        self._next_id += 1
+        await self._send({"jsonrpc": "2.0", "id": req_id, "method": "tools/list"})
+        line = await self._read_line()
+        return json.loads(line)
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any], *, timeout: float = 30.0
+    ) -> dict[str, Any]:
+        """Send tools/call; return the parsed JSON-RPC response.
+
+        Custom timeout for tool calls — semantic search with a cold-cache
+        embedder pays ~25s on Linux CPU. Default 30s; cold-cache tests
+        override.
+        """
+        req_id = self._next_id
+        self._next_id += 1
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        line = await self._read_line(timeout=timeout)
+        return json.loads(line)
+
+    async def close(self) -> None:
+        """Close stdin (signals EOF), then wait briefly for graceful exit
+        before SIGTERM → SIGKILL escalation."""
+        import contextlib
+
+        with contextlib.suppress(BrokenPipeError, OSError):
+            self._stdin.close()
+
+        # Give the server up to 2s to exit cleanly after stdin EOF.
+        loop = asyncio.get_event_loop()
+        try:
+            await asyncio.wait_for(loop.run_in_executor(None, self._proc.wait), timeout=2.0)
+        except TimeoutError:
+            self._proc.send_signal(signal.SIGTERM)
+            try:
+                await asyncio.wait_for(loop.run_in_executor(None, self._proc.wait), timeout=2.0)
+            except TimeoutError:
+                self._proc.kill()
+                await loop.run_in_executor(None, self._proc.wait)
+
+    @property
+    def returncode(self) -> int | None:
+        return self._proc.returncode
+
+    def stderr_text(self) -> str:
+        """Read accumulated stderr (test assertions check this)."""
+        if not self._stderr_path.exists():
+            return ""
+        return self._stderr_path.read_text(encoding="utf-8", errors="replace")
+
+    def stdout_lines_so_far(self) -> int:
+        """Count how many newline-terminated lines have been written to
+        stdout so far. Used by tests asserting "exactly N lines on stdout"
+        — we already consumed them via _read_line, but this returns the
+        cumulative request-counter as a proxy (one response per request)."""
+        return self._next_id - 1
+
+
+def _resolve_recall_binary() -> str:
+    """Find the ``recall`` console script that lives in the same venv as
+    the test runner.
+
+    Resolution path: ``Path(sys.executable).parent / "recall"``. Under
+    uv, ``sys.executable`` is ``<venv>/bin/python3``, so its parent
+    dir holds the console scripts that ``pyproject.toml``'s
+    ``[project.scripts]`` block creates at install time
+    (``recall = "recall.cli:main"``).
+
+    Why not ``python -m recall.cli serve``? ``src/recall/cli.py`` has
+    no ``if __name__ == "__main__": main()`` guard, so invoking it via
+    ``-m`` imports the module but never calls ``app()``. The process
+    starts, exits cleanly with rc=0, prints nothing — silent and
+    confusing failure mode. Initial 3.11 implementation hit this
+    exact wall before pivoting to the console script.
+
+    Why won't we add ``__main__`` to ``cli.py``? The CLI is invoked
+    via the installed console script — that's the intentional public
+    entrypoint and matches how ``recall`` is shipped on PyPI / via
+    ``uvx recall-mcp``. Adding ``__main__`` would create a second
+    entrypoint surface that diverges from how real users invoke
+    Recall, exactly the kind of "test-only path" that drifts and
+    masks production bugs (cf. CLAUDE.md "imports passing ≠ behavior
+    correct" lesson from 2.5). We test the actual public entrypoint.
+
+    3.12 inheritance: the recorded-session replay tests use the same
+    ``mcp_subprocess_session`` / ``mcp_subprocess_factory`` fixtures
+    and inherit this constraint. If 3.12 ever needs a different
+    entrypoint, surface it explicitly during planning — don't quietly
+    work around it here.
+    """
+    bin_dir = Path(sys.executable).parent
+    recall_bin = bin_dir / "recall"
+    if not recall_bin.exists():
+        raise RuntimeError(
+            f"recall console script not found at {recall_bin}. Did `uv sync` install the package?"
+        )
+    return str(recall_bin)
+
+
+@pytest.fixture
+async def mcp_subprocess_session(
+    tmp_path: Path,
+) -> AsyncIterator[Any]:
+    """Spawn ``recall serve``; yield a session helper.
+
+    Default environment: clean ``HF_HOME`` is NOT set (production cache
+    used). Tests that need cold-cache isolation pass an override via the
+    factory variant ``mcp_subprocess_factory`` below.
+
+    Default ``RECALL_DB_PATH`` points at a unique non-existent path under
+    tmp_path so the server boots in no-index state and tests don't leak
+    into the maintainer's ~/.recall/db.sqlite.
+
+    Cleanup: on test exit, closes stdin → waits 2s → SIGTERM → SIGKILL.
+    """
+    stderr_path = tmp_path / "recall_serve.stderr.log"
+    env = os.environ.copy()
+    env["RECALL_DB_PATH"] = str(tmp_path / "test-default-empty.sqlite")
+    env["PYTHONUNBUFFERED"] = "1"
+
+    proc = subprocess.Popen(
+        [_resolve_recall_binary(), "serve"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=stderr_path.open("wb"),
+        env=env,
+        bufsize=0,  # Unbuffered — we want byte-for-byte stdout
+    )
+
+    session = MCPSubprocessSession(proc, stderr_path)
+    try:
+        yield session
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+def mcp_subprocess_factory(tmp_path: Path):
+    """Factory variant — tests parameterize env / db_path / etc. then own
+    cleanup explicitly. Used by tests that need isolated_hf_cache or a
+    pre-populated fixture DB.
+
+    Returns an async function. Caller awaits it to spawn, manages
+    teardown via ``await session.close()`` in a try/finally.
+    """
+    spawned: list[MCPSubprocessSession] = []
+
+    async def _spawn(
+        *,
+        env_overrides: dict[str, str] | None = None,
+        db_path: Path | None = None,
+        stderr_filename: str = "recall_serve.stderr.log",
+    ) -> MCPSubprocessSession:
+        stderr_path = tmp_path / stderr_filename
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+        if db_path is not None:
+            env["RECALL_DB_PATH"] = str(db_path)
+        else:
+            env["RECALL_DB_PATH"] = str(tmp_path / f"db-{len(spawned)}.sqlite")
+        if env_overrides:
+            env.update(env_overrides)
+
+        proc = subprocess.Popen(
+            [_resolve_recall_binary(), "serve"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr_path.open("wb"),
+            env=env,
+            bufsize=0,
+        )
+        session = MCPSubprocessSession(proc, stderr_path)
+        spawned.append(session)
+        return session
+
+    yield _spawn
+
+    # Teardown: close all spawned sessions.
+    async def _cleanup() -> None:
+        for s in spawned:
+            await s.close()
+
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # Already inside an async test — tests are responsible for
+            # closing their own sessions; this is a fallback.
+            for s in spawned:
+                if s._proc.returncode is None:
+                    s._proc.kill()
+        else:
+            loop.run_until_complete(_cleanup())
+    except RuntimeError:
+        # No event loop available; do best-effort sync cleanup.
+        for s in spawned:
+            if s._proc.returncode is None:
+                s._proc.kill()
+
+
+# === Cold-cache fixtures ===
+
+
+@pytest.fixture
+def isolated_hf_cache(tmp_path: Path) -> dict[str, str]:
+    """Return env vars that point HuggingFace's cache to an empty tmpdir.
+
+    F2 + §7 lock: cache-warming defeats the cold-cache test's purpose.
+    Setting HF_HOME (and the legacy TRANSFORMERS_CACHE / HF_HUB_CACHE)
+    to an empty tmpdir forces a fresh download-or-cache-load on every
+    test invocation. The cost (~25s on Linux CPU) is the cost of
+    correctness.
+
+    Sanity check (per the verification refinement): cold-cache test
+    runtime under 2s on M-series indicates the isolation isn't working
+    — manual_smoke.md Section D documents this assertion.
+
+    Network dependency: this fixture requires HF infra to serve the
+    bge-small-en-v1.5 model. Failure mode if HF is down: clean
+    network error in stderr, NOT a stdio-cleanliness false positive.
+    """
+    cache_root = tmp_path / "hf_cache"
+    cache_root.mkdir()
+    return {
+        "HF_HOME": str(cache_root),
+        "TRANSFORMERS_CACHE": str(cache_root / "transformers"),
+        "HF_HUB_CACHE": str(cache_root / "hub"),
+    }
+
+
+@pytest.fixture
+def fixture_indexed_db(tmp_path: Path) -> Path:
+    """Build a tiny synthetic-vector DB matching the production schema.
+
+    §7 option C lock: hand-insert 10 commands + their dim=384 vectors
+    via the test_indexer.py FakeEmbedder384 pattern. Cheap (~10ms). The
+    cold-cache subprocess test then dispatches search against this DB;
+    the SUBPROCESS pays the embedder lazy-load cost when it encodes the
+    query, which is the point of the cold-cache test.
+
+    Returns the path to a migrated, populated DB at tmp_path/db.sqlite.
+    """
+    # Lazy import: keep conftest.py's import-time cost low for tests
+    # that don't need this fixture.
+    from recall.db import connect, migrate, set_meta
+    from recall.embed import DEFAULT_MODEL
+
+    db_path = tmp_path / "fixture-db.sqlite"
+    conn = connect(db_path)
+    migrate(conn)
+    set_meta(conn, "embedding_model_name", DEFAULT_MODEL)
+
+    # 10 plausible commands; deterministic hash for the test_hash; ts
+    # spread over a few minutes so ORDER BY ts DESC is meaningful.
+    commands = [
+        ("zsh", "git status", 1000, "/home/u/proj"),
+        ("zsh", "git diff", 1010, "/home/u/proj"),
+        ("zsh", "ls -la", 1020, "/home/u/proj"),
+        ("zsh", "cd /tmp", 1030, "/tmp"),
+        ("zsh", "docker ps", 1040, "/home/u/proj"),
+        ("zsh", "kubectl get pods", 1050, "/home/u/proj"),
+        ("zsh", "psql -h localhost", 1060, "/home/u/proj"),
+        ("zsh", "make test", 1070, "/home/u/proj"),
+        ("zsh", "uv sync", 1080, "/home/u/proj"),
+        ("zsh", "pytest -xvs", 1090, "/home/u/proj"),
+    ]
+    for source, text, ts, cwd in commands:
+        # Synthetic dim=384 vector via the test_indexer pattern.
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        small = np.frombuffer(digest[:16], dtype=np.uint8).astype(np.float32)
+        small -= 128.0
+        tiled = np.tile(small, 24).astype(np.float32)
+        norm = float(np.linalg.norm(tiled))
+        vec = tiled / (norm if norm > 0 else 1.0)
+
+        text_hash = (text.encode("utf-8") + b"\x00" * 32)[:32]
+        cur = conn.execute(
+            "INSERT INTO commands (source, text_scrubbed, text_hash, cwd, ts) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (source, text, text_hash, cwd, ts),
+        )
+        cmd_id = int(cur.lastrowid or 0)
+        vec_blob = np.ascontiguousarray(vec.astype(np.float32)).tobytes()
+        conn.execute(
+            "INSERT INTO commands_vec (command_id, embedding) VALUES (?, ?)",
+            (cmd_id, vec_blob),
+        )
+    conn.close()
+    return db_path
+
+
+# Expose sqlite3 so tests can construct connections via the standard module
+# path even if the import doesn't appear used at top level.
+_ = sqlite3

--- a/tests/manual_smoke.md
+++ b/tests/manual_smoke.md
@@ -386,3 +386,92 @@ The full Section B (each of the six tools against an indexed DB) +
 Section C (Claude Desktop UX confirmation) are run by the maintainer
 before squash-merge of this branch and again at every meaningful
 change to `tools.py` or `server.py`.
+
+---
+
+## Section D — stdio-cleanliness suite (3.11)
+
+This section is the in-process equivalent of the `stdio (ubuntu /
+py3.12)` CI lane added in Commit 3.11 — same tests, run locally on
+M-series. The CI lane is Linux-only per the F2 lock at 3.11 plan;
+this section is **the maintainer's M-series local verification**,
+which is a v1.0 launch-checklist item per CLAUDE.md "Deferred items."
+
+The lane source lives at `tests/test_stdio_cleanliness.py`. Six tests:
+
+- **A** initialize-only round-trip
+- **C** initialize + tools/call recent (no-index dispatch isolation)
+- **D** cold-cache tools/call search (the marquee test — empty
+  HF_HOME, fresh model download)
+- **E** lazy-refresh transition end-to-end (subprocess wiring of
+  the 3.10 first-run UX fix)
+- **AST check** rejects sys.stdout writes / StreamHandler(sys.stdout)
+  / print(..., file=sys.stdout) in src/recall/
+- **T201 invocation** runs `ruff check --select T201 src/recall/`
+  as a subprocess
+
+### Pre-run sanity check (the §7 isolation refinement)
+
+Before running test D, verify two things:
+
+1. **Warm HF cache exists** — `~/.cache/huggingface` should already
+   hold the bge-small-en-v1.5 model from prior dev work. This is the
+   BASELINE the test is contrasting against: when isolation works,
+   the test pays a real download/load cost (~5-25s on M-series, ~25s
+   on Linux). When isolation is broken, the test would unintentionally
+   reuse this warm cache and complete in <2s.
+
+   ```bash
+   ls -d ~/.cache/huggingface 2>&1 || \
+     echo "WARNING: no HF cache yet; first run will pay full download cost"
+   ```
+
+2. **Test D pays load cost** — assert wall time is ≥2s (M-series).
+   If completion <2s, the `isolated_hf_cache` fixture isn't actually
+   isolating — investigate before trusting any result.
+
+   ```bash
+   time uv run pytest tests/test_stdio_cleanliness.py::test_cold_cache_search_clean_stdout
+   ```
+
+### The procedure
+
+```bash
+# Non-embed tests (A, C, E, AST, T201) — fast (~5s)
+uv run pytest tests/test_stdio_cleanliness.py -v -m "not embed"
+
+# Cold-cache marquee test — separate so runtime is visible
+time uv run pytest tests/test_stdio_cleanliness.py::test_cold_cache_search_clean_stdout -v
+```
+
+### Assertion checklist
+
+- [ ] Tests A, C, E, AST check, T201 all pass (~5s combined).
+- [ ] Test D passes; wall time ≥2s on M-series (confirms isolation).
+- [ ] No Python tracebacks anywhere.
+- [ ] No WARNING/ERROR/CRITICAL log lines (`_assert_stderr_clean`
+      fires if any).
+
+### Last verified output (M-series local, 3.11 implementation)
+
+Tests A, C, E, AST check, T201 ran in **1.84s** combined. Test D
+(cold-cache, with `isolated_hf_cache` forcing fresh model load via
+empty HF_HOME) ran in **22.65s** — well above the 2s sanity
+threshold, confirming cache isolation. All 6 tests passed; zero
+tracebacks; zero stderr warnings.
+
+```
+tests/test_stdio_cleanliness.py::test_initialize_only_clean_stdout PASSED
+tests/test_stdio_cleanliness.py::test_recent_no_index_clean_stdout PASSED
+tests/test_stdio_cleanliness.py::test_lazy_refresh_subprocess PASSED
+tests/test_stdio_cleanliness.py::test_no_stdout_writes_in_src PASSED
+tests/test_stdio_cleanliness.py::test_ruff_t201_clean PASSED
+tests/test_stdio_cleanliness.py::test_cold_cache_search_clean_stdout PASSED  [22.65s]
+```
+
+### Pre-launch (v1.0 announce) re-run
+
+Per CLAUDE.md "Deferred items" → "v1.0 launch checklist: cold-cache
+subprocess test on local M-series Mac" — re-run test D before v1.0
+announcement and append the result here (or to `docs/clients-tested.md`
+once Commit 3.13 lands that file).

--- a/tests/test_stdio_cleanliness.py
+++ b/tests/test_stdio_cleanliness.py
@@ -1,0 +1,433 @@
+"""Stdio cleanliness test suite (Commit 3.11).
+
+Binds the CLAUDE.md §5 invariant: "after ``stdio_server()`` opens the
+protocol loop, NO byte may reach stdout except an MCP JSON-RPC frame."
+
+Six categories:
+  Subprocess A — initialize-only round-trip
+  Subprocess C — initialize + tools/call recent (no-index dispatch isolation)
+  Subprocess D — cold-cache tools/call search (the marquee test)
+  Subprocess E — lazy-refresh transition end-to-end (subprocess wiring)
+  Static AST  — rejects sys.stdout writes / StreamHandler(sys.stdout) /
+                print(..., file=sys.stdout) in src/recall/
+  Static T201 — runs ruff --select T201 over src/recall/ as a subprocess
+
+Lane: dedicated ``stdio`` lane on Ubuntu py3.12. Per F2 lock: Linux-only
+for v1; M-series cleanliness verified via manual smoke (see
+tests/manual_smoke.md Section D).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# === Subprocess test A: initialize-only round-trip ===
+
+
+@pytest.mark.asyncio
+async def test_initialize_only_clean_stdout(mcp_subprocess_session) -> None:
+    """Send only ``initialize``; assert one valid MCP response on stdout
+    and no Python tracebacks on stderr.
+
+    Tests transport-level cleanliness independent of tool dispatch.
+    """
+    result = await mcp_subprocess_session.initialize()
+
+    # JSON-RPC envelope shape
+    assert result.get("jsonrpc") == "2.0"
+    assert result.get("id") == 1
+    assert "result" in result, f"expected result, got {result}"
+    assert "error" not in result
+
+    inner = result["result"]
+    assert inner.get("protocolVersion"), "missing protocolVersion"
+    assert inner.get("serverInfo", {}).get("name") == "recall-mcp"
+    assert inner.get("serverInfo", {}).get("version") == "0.0.1"
+
+    # Stderr cleanliness assertion (§8 strengthening): no tracebacks,
+    # no WARNING / ERROR. INFO is fine.
+    _assert_stderr_clean(mcp_subprocess_session.stderr_text())
+
+
+# === Subprocess test C: tools/call recent (no-index dispatch isolation) ===
+
+
+@pytest.mark.asyncio
+async def test_recent_no_index_clean_stdout(mcp_subprocess_session) -> None:
+    """Send initialize + initialized + tools/call recent against an empty
+    DB path. Asserts the no-index error payload is well-formed.
+
+    Diagnostic isolation: if this passes and D fails, the encode path is
+    the culprit; if both fail, dispatch is.
+    """
+    init = await mcp_subprocess_session.initialize()
+    assert init.get("result"), f"initialize failed: {init}"
+
+    await mcp_subprocess_session.notify_initialized()
+
+    resp = await mcp_subprocess_session.call_tool("recent", {"limit": 3})
+
+    # JSON-RPC envelope
+    assert resp.get("jsonrpc") == "2.0"
+    assert "result" in resp
+    inner = resp["result"]
+
+    # State error: isError=True with the user-facing no_index message
+    assert inner.get("isError") is True
+    assert inner.get("structuredContent", {}).get("error"), (
+        f"missing error in structuredContent: {inner}"
+    )
+    msg = inner["structuredContent"]["error"]
+    assert "Index not found" in msg, f"unexpected error message: {msg}"
+
+    _assert_stderr_clean(mcp_subprocess_session.stderr_text())
+
+
+# === Subprocess test E: lazy-refresh transition end-to-end ===
+
+
+@pytest.mark.asyncio
+async def test_lazy_refresh_subprocess(
+    mcp_subprocess_factory,
+    tmp_path: Path,
+) -> None:
+    """Boot without a DB; first tools/call returns no_index; create the
+    DB mid-session via direct INSERT (refinement: synthetic fixture, NOT
+    a subprocess ``recall index`` call — that composition test belongs
+    in 3.12); second tools/call returns results.
+
+    Asserts the refresh transition fires end-to-end through the
+    subprocess + MCP framing layers, not just the unit-tested function
+    path in test_server.py.
+    """
+    db_path = tmp_path / "refresh-db.sqlite"
+    session = await mcp_subprocess_factory(db_path=db_path)
+
+    try:
+        await session.initialize()
+        await session.notify_initialized()
+
+        # First call: no_index error.
+        first = await session.call_tool("recent", {"limit": 5})
+        assert first["result"]["isError"] is True
+        assert "Index not found" in first["result"]["structuredContent"]["error"]
+
+        # Build a tiny DB at the path the server is watching. Synthetic
+        # fixture per the locked refinement — surgical test of "server
+        # detects new DB and refreshes wiring," not of indexer integration.
+        _build_tiny_indexed_db(db_path)
+
+        # Second call: refresh fires; results returned. The protocol-
+        # level transition (no_index → real results in a single process)
+        # is the proof the refresh wiring is intact. The "state refreshed
+        # — index detected" log line goes to recall.log (RotatingFileHandler
+        # at ~/.recall/logs/), NOT stderr — setup_logging removes all
+        # stderr handlers. We don't sniff the log file here; the unit
+        # tests in test_server.py already cover the function path with
+        # the log-line probe.
+        second = await session.call_tool("recent", {"limit": 5})
+        assert second["result"]["isError"] is False, f"refresh did not transition; got: {second}"
+        results = second["result"]["structuredContent"]["results"]
+        assert len(results) >= 1, "no results returned after refresh"
+
+        _assert_stderr_clean(session.stderr_text())
+    finally:
+        await session.close()
+
+
+# === Subprocess test D: cold-cache search (the marquee test) ===
+
+
+@pytest.mark.asyncio
+@pytest.mark.embed  # depends on sentence-transformers; runs in stdio lane
+async def test_cold_cache_search_clean_stdout(
+    mcp_subprocess_factory,
+    isolated_hf_cache: dict[str, str],
+    fixture_indexed_db: Path,
+) -> None:
+    """Marquee cold-cache test. Spawn ``recall serve`` with empty
+    HF_HOME (forces fresh sentence-transformers download/load), send
+    initialize + initialized + tools/call search.
+
+    Assert: response is a well-formed JSON-RPC frame; no library
+    progress bars / warnings / load messages on stdout. Asserts the
+    redirect_stdout(sys.stderr) defense actually works under cold-load.
+
+    Runtime: ~25s on Linux CPU. 90s timeout per the locked refinement
+    R1 — distinguishes "HF download exceeded budget" from "stdout
+    pollution" in CI logs.
+
+    NETWORK DEPENDENCY: HF infra availability. If HF is down, this
+    fails with a clear network error in stderr, NOT a stdio-cleanliness
+    false positive. Recovery: if cold-cache fails on daily run with
+    network error, re-run once. Twice consecutive = real signal (check
+    status.huggingface.co or treat as regression).
+    """
+    session = await mcp_subprocess_factory(
+        env_overrides=isolated_hf_cache,
+        db_path=fixture_indexed_db,
+    )
+    try:
+        await session.initialize()
+        await session.notify_initialized()
+
+        # 90s timeout — cold cache (fresh HF download + first encode +
+        # MPS warmup, though MPS doesn't apply on Linux) is ~25s on
+        # Linux CPU. The remaining headroom absorbs CI variance.
+        try:
+            resp = await session.call_tool(
+                "search",
+                {"query": "git status", "limit": 3},
+                timeout=90.0,
+            )
+        except TimeoutError as e:
+            stderr = session.stderr_text()
+            pytest.fail(
+                "cold-cache search exceeded 90s timeout. This is the "
+                "DIAGNOSABLE-FAILURE marker (R1): could be HF download "
+                "exceeded budget OR genuine stdout pollution masking the "
+                "response. Inspect stderr below to distinguish.\n"
+                f"original error: {e}\n"
+                f"stderr (last 4000 chars):\n{stderr[-4000:]}"
+            )
+
+        # Response shape: well-formed JSON-RPC, well-formed CallToolResult
+        assert resp.get("jsonrpc") == "2.0"
+        assert "result" in resp, f"expected result, got: {resp}"
+        inner = resp["result"]
+        assert inner.get("isError") is False, (
+            f"search returned error under cold cache:\n"
+            f"  result: {inner}\n"
+            f"  stderr: {session.stderr_text()[-2000:]}"
+        )
+
+        results = inner["structuredContent"]["results"]
+        assert len(results) >= 1, "expected ≥1 search result against fixture DB"
+        # Each result must have the expected CommandHit shape — cold cache
+        # producing structurally-broken output would indicate the encode
+        # path silently degraded.
+        for r in results:
+            assert "id" in r and "text" in r and "score" in r, (
+                f"malformed CommandHit under cold cache: {r}"
+            )
+
+        # The load-bearing assertion: no library leaks on the stdout
+        # path. We've already received valid JSON for every frame; the
+        # check below ensures stderr (where progress bars SHOULD go,
+        # if anywhere) doesn't contain Python tracebacks. Mere progress
+        # bar text on stderr is fine.
+        _assert_stderr_clean(session.stderr_text())
+    finally:
+        await session.close()
+
+
+# === Static analysis: AST check ===
+
+
+def test_no_stdout_writes_in_src() -> None:
+    """Walk every .py under src/recall/; reject any direct stdout write.
+
+    Rejection rules (§4 option B + flag refinement F4):
+      - sys.stdout.write(...)
+      - os.write(1, ...)         # fd 1 is stdout
+      - StreamHandler(sys.stdout) / StreamHandler(stream=sys.stdout)
+      - print(..., file=sys.stdout)
+
+    The runtime gate `_assert_no_stdout_handler` covers the
+    StreamHandler(sys.stdout) case at boot. This AST check makes the
+    rule fail at PR time, before runtime, on code paths the tests don't
+    execute.
+    """
+    src_root = Path(__file__).parent.parent / "src" / "recall"
+    violations: list[str] = []
+
+    for py_file in src_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except SyntaxError as e:
+            pytest.fail(f"syntax error in {py_file}: {e}")
+
+        for node in ast.walk(tree):
+            v = _check_node(node, py_file, src_root)
+            if v:
+                violations.append(v)
+
+    if violations:
+        msg = "\n".join(violations)
+        pytest.fail(
+            f"AST check found {len(violations)} stdout-write violations:\n{msg}\n\n"
+            "These bypass the redirect_stdout defense and break MCP framing. "
+            "Use stderr or a file handler instead."
+        )
+
+
+def _check_node(node: ast.AST, py_file: Path, src_root: Path) -> str | None:
+    """Return a violation string if this AST node writes to stdout, else None."""
+    rel = py_file.relative_to(src_root.parent.parent)
+    loc = f"  {rel}:{getattr(node, 'lineno', '?')}"
+
+    # 1. sys.stdout.write(...)
+    if isinstance(node, ast.Call):
+        f = node.func
+        if (
+            isinstance(f, ast.Attribute)
+            and f.attr == "write"
+            and isinstance(f.value, ast.Attribute)
+            and f.value.attr == "stdout"
+            and isinstance(f.value.value, ast.Name)
+            and f.value.value.id == "sys"
+        ):
+            return f"{loc}: sys.stdout.write(...) — write to stderr or use logging"
+
+        # 2. os.write(1, ...) where 1 is fd stdout
+        if (
+            isinstance(f, ast.Attribute)
+            and f.attr == "write"
+            and isinstance(f.value, ast.Name)
+            and f.value.id == "os"
+            and len(node.args) >= 1
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == 1
+        ):
+            return f"{loc}: os.write(1, ...) — fd 1 is stdout; use stderr (fd 2)"
+
+        # 3. StreamHandler(sys.stdout) — positional or keyword form
+        if (isinstance(f, ast.Name) and f.id == "StreamHandler") or (
+            isinstance(f, ast.Attribute) and f.attr == "StreamHandler"
+        ):
+            for arg in node.args:
+                if _is_sys_stdout(arg):
+                    return f"{loc}: StreamHandler(sys.stdout) — must target stderr or a file"
+            for kw in node.keywords:
+                if kw.arg == "stream" and _is_sys_stdout(kw.value):
+                    return f"{loc}: StreamHandler(stream=sys.stdout) — must target stderr or a file"
+
+        # 4. print(..., file=sys.stdout) — closes the gap T201 might miss
+        if isinstance(f, ast.Name) and f.id == "print":
+            for kw in node.keywords:
+                if kw.arg == "file" and _is_sys_stdout(kw.value):
+                    return f"{loc}: print(..., file=sys.stdout) — bypass via file= kwarg"
+
+    return None
+
+
+def _is_sys_stdout(node: ast.AST) -> bool:
+    """True if ``node`` is an AST reference to ``sys.stdout``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "stdout"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+    )
+
+
+# === Static analysis: T201 invocation ===
+
+
+def test_ruff_t201_clean() -> None:
+    """Run ``ruff check --select T201 src/recall/`` directly. Asserts
+    zero T201 violations.
+
+    Belt-and-suspenders against someone bypassing the global ruff config
+    (e.g. a per-file ignore that accidentally widens scope). Independent
+    of the per-PR ``ruff check .`` step.
+    """
+    src_root = Path(__file__).parent.parent / "src" / "recall"
+    result = subprocess.run(
+        ["ruff", "check", "--select", "T201", str(src_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"ruff T201 violations in src/recall/:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+# === Helpers ===
+
+
+def _assert_stderr_clean(stderr: str) -> None:
+    """Assert stderr contains no Python tracebacks and no WARNING/ERROR
+    log lines (§8 strengthening). INFO is fine.
+
+    Filters out the uv/setup environment warnings that aren't from
+    recall.* loggers — those are infrastructure, not server cleanliness.
+    """
+    if "Traceback" in stderr:
+        pytest.fail(f"Python traceback in stderr:\n{stderr[-4000:]}")
+
+    # Walk lines; flag any line containing WARNING or ERROR that's a
+    # recall.* log entry. We match the ``setup_logging`` formatter:
+    #   "%(asctime)s %(levelname)s %(name)s %(message)s"
+    # so WARNING / ERROR appear in column 2.
+    bad: list[str] = []
+    for line in stderr.splitlines():
+        # Skip uv setup chatter and the venv mismatch warning that
+        # appears even in passing runs.
+        if "VIRTUAL_ENV" in line or "Building recall" in line or "Built recall" in line:
+            continue
+        if "Uninstalled" in line or "Installed" in line:
+            continue
+        # Match recall logger format: "<ts> WARNING <name> ..."
+        for level in ("WARNING", "ERROR", "CRITICAL"):
+            # Look for level token surrounded by whitespace (not WARN-ed
+            # or NotEr...; clear word boundary).
+            if f" {level} " in f" {line} ":
+                bad.append(line)
+                break
+    if bad:
+        pytest.fail(
+            f"stderr contains {len(bad)} WARNING/ERROR/CRITICAL line(s):\n" + "\n".join(bad)
+        )
+
+
+def _build_tiny_indexed_db(db_path: Path) -> None:
+    """Hand-build a small DB at db_path matching the production schema.
+
+    Used by test E (lazy-refresh subprocess). Synthetic vectors per the
+    locked refinement — surgical "did the server detect a new DB?"
+    test, not an indexer integration test.
+    """
+    import hashlib
+
+    from recall.db import connect, migrate, set_meta
+    from recall.embed import DEFAULT_MODEL
+
+    conn = connect(db_path)
+    migrate(conn)
+    set_meta(conn, "embedding_model_name", DEFAULT_MODEL)
+
+    text = "test command for refresh"
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    small = np.frombuffer(digest[:16], dtype=np.uint8).astype(np.float32)
+    small -= 128.0
+    tiled = np.tile(small, 24).astype(np.float32)
+    norm = float(np.linalg.norm(tiled))
+    vec = tiled / (norm if norm > 0 else 1.0)
+    text_hash = (text.encode("utf-8") + b"\x00" * 32)[:32]
+    cur = conn.execute(
+        "INSERT INTO commands (source, text_scrubbed, text_hash, ts) VALUES (?, ?, ?, ?)",
+        ("zsh", text, text_hash, 1000),
+    )
+    cmd_id = int(cur.lastrowid or 0)
+    vec_blob = np.ascontiguousarray(vec.astype(np.float32)).tobytes()
+    conn.execute(
+        "INSERT INTO commands_vec (command_id, embedding) VALUES (?, ?)",
+        (cmd_id, vec_blob),
+    )
+    conn.close()
+
+
+# Used by sys-stdout reference. Quiet linters that flag the import as
+# unused (it's referenced via ast in the AST check, not at module level).
+_ = sys


### PR DESCRIPTION
## Summary

Commit 3.11 of the locked Phase 3 build: stdio cleanliness CI test suite. Binds the CLAUDE.md §5 invariant ("after `stdio_server()` opens the protocol loop, NO byte may reach stdout except an MCP JSON-RPC frame") into a CI gate. Until 3.11 the invariant was runtime gates + manual smoke; 3.11 makes regressions fail PR.

- **6 new tests** (`tests/test_stdio_cleanliness.py`): initialize-only, tools/call-recent (no-index dispatch isolation), cold-cache search (the marquee test — empty `HF_HOME`, fresh model download), lazy-refresh subprocess (3.10 first-run UX wiring), AST check, ruff T201 invocation
- **New `stdio (ubuntu / py3.12)` CI lane** runs on every PR + main push + daily 06:00 UTC. Linux-only for v1 per F2 lock; M-series via maintainer manual smoke (`tests/manual_smoke.md` Section D — added)
- **Reusable subprocess fixture** in `tests/conftest.py` — `MCPSubprocessSession` class with helper API (`initialize` / `notify_initialized` / `list_tools` / `call_tool` / `close` / `stderr_text`). 3.12 inherits without modification per locked plan
- **T201 enabled** in `pyproject.toml` with per-file-ignores for `tests/**`, `.github/scripts/*.py`, and `src/recall/indexer.py` (CLI, not stdio path)
- **AST check** rejects `sys.stdout.write` / `os.write(1, ...)` / `StreamHandler(sys.stdout)` / `print(..., file=sys.stdout)` in `src/recall/`

## Findings worth flagging

- **T201 + AST split was load-bearing.** T201 caught two `print(..., file=sys.stderr)` calls in `indexer.py` during first-run — safe (CLI command, explicit stderr), but T201 doesn't differentiate. Per-file-ignore added with documented rationale; CLAUDE.md §5 captures the engineering insight for future contributors.
- **`python -m recall.cli serve` doesn't work** — no `__main__` guard. Subprocess fixture uses `_resolve_recall_binary()` finding the venv's recall console script via `Path(sys.executable).parent`. Won't add `__main__`: console script is the intentional public entrypoint; second entrypoint would be a test-only-path drift risk (cf. 2.5 "imports passing ≠ behavior correct").
- **Cold-cache runtime variance** (18-23s M-series local) comes from HF infra latency, not recall. 90s timeout has plenty of headroom.

## Test plan

- [x] `pytest -m "not embed"` — 303 passed (5 new non-embed stdio tests)
- [x] Cold-cache test (test D) on M-series — 18.95s (above 2s isolation threshold; cache isolation working as designed)
- [x] `pytest -m embed --ignore=tests/test_stdio_cleanliness.py` — 9 passed (matches CI embed lane invocation)
- [x] `pytest -k scrub` — 122 canary clean
- [x] `ruff check .` + `ruff format --check .` — clean (T201 enforced; per-file-ignores documented)
- [x] `mypy src` — 26 files, 0 errors
- [ ] **CI watch**: confirm new `stdio` lane lands in 18-25s range on Linux CPU; cold-cache test passes

## CI on this PR

Expected lanes:
```
fast (macos × py3.11/3.12/3.13)    pass  ~1m each (T201 enabled now)
fast (ubuntu × py3.11/3.12/3.13)   pass  ~1m each
embed (ubuntu / py3.12)            pass  ~20-23m (test D excluded via --ignore)
stdio (ubuntu / py3.12)            pass  ~30s (NEW — A+C+D+E+AST+T201)
scrubber test count canary         skip  (scrub.py untouched)
```

Daily 06:00 UTC schedule will fire the `stdio` lane only — workflow has `if: github.event_name != 'schedule'` on fast/embed/scrub-canary.

## Files

```
 tests/test_stdio_cleanliness.py   +433  (NEW)
 tests/conftest.py                 +401
 CLAUDE.md                         +95
 tests/manual_smoke.md             +89
 .github/workflows/ci.yml          +46
 pyproject.toml                    +18
```

No live Claude Desktop smoke needed — server surface didn't change. Section D manual smoke captured in `manual_smoke.md` per locked plan.