### PR TITLE
test(replay): recorded MCP session fixtures + replay engine (Commit 3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,15 @@ jobs:
       - name: mypy
         run: uv run --python ${{ matrix.python-version }} mypy src
       - name: pytest (no embed)
-        run: uv run --python ${{ matrix.python-version }} pytest -m "not embed"
+        # Fast lane excludes tests/test_recorded_sessions.py — those are
+        # subprocess-driven MCP protocol-conformance tests owned by the
+        # `stdio` lane (locked Phase 3.12 §9). Running them here too
+        # would (a) duplicate the work N×matrix-cells and (b) spread
+        # S1's 30s idle cost across every cell. See the comment on the
+        # `stdio` job below for the lane-ownership boundary.
+        run: |
+          uv run --python ${{ matrix.python-version }} pytest -m "not embed" \
+            --ignore=tests/test_recorded_sessions.py
 
   embed:
     name: embed (ubuntu / py3.12)
@@ -117,18 +125,33 @@ jobs:
   stdio:
     name: stdio (ubuntu / py3.12)
     runs-on: ubuntu-latest
-    # 3.11 dedicated lane: subprocess + cold-cache stress + AST + T201
-    # invocation. Per CLAUDE.md §5 + the F2 lock at 3.11 plan:
-    #  - stdio cleanliness invariant lives here
-    #  - Linux-only for v1; M-series cleanliness verified via maintainer
-    #    manual smoke (tests/manual_smoke.md Section D)
-    #  - daily schedule trigger catches upstream regressions (e.g. HF
-    #    adds progress bar in a future release silently)
+    # === Lane ownership boundary (locked Phase 3.11 + 3.12 §9) ===
     #
-    # Runtime envelope: ~30s (cold-cache pays ~25s for HF download +
-    # model load on Linux CPU; AST/T201 ≈ <1s; subprocess scaffolding
-    # ≈ ~5s). If lane runtime grows past 90s, investigate (see
-    # CLAUDE.md "Performance budgets").
+    # The `stdio` lane owns ALL subprocess-driven MCP tests:
+    #   - tests/test_stdio_cleanliness.py (3.11): transport invariant —
+    #     subprocess + cold-cache stress + AST check + T201 invocation.
+    #   - tests/test_recorded_sessions.py (3.12): protocol conformance —
+    #     5 recorded scenarios (S1 long_idle, S2 happy_path, S3 error
+    #     recovery, S4 multiple_back_to_back, S6 pipelined_requests) +
+    #     loader/matcher self-tests.
+    #
+    # Both files share the MCPSubprocessSession fixture and the
+    # subprocess setup cost; running them in the same lane amortizes
+    # checkout + uv sync once. Fast lane excludes test_recorded_sessions
+    # via --ignore (see fast lane above) so S1's 30s idle test isn't
+    # paid 6× across the matrix.
+    #
+    # Per F2 lock (3.11): Linux-only for v1; M-series stdio cleanliness
+    # verified via maintainer manual smoke (tests/manual_smoke.md
+    # Section D). Daily schedule trigger catches upstream regressions
+    # (e.g. HF adds progress bar in a future release silently; SDK
+    # update changes initialize-response shape; etc.).
+    #
+    # Runtime envelope: ~50s (cold-cache ~25s + S1 idle 30s + ~5s
+    # remaining; some overlap from concurrent test execution). If
+    # lane runtime grows past 90s on three consecutive runs, evaluate
+    # splitting into transport-cleanliness vs protocol-conformance
+    # lanes per CLAUDE.md "Deferred items".
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -138,13 +161,17 @@ jobs:
         run: uv python install 3.12
       - name: sync deps
         run: uv sync --python 3.12
-      - name: stdio cleanliness suite (subprocess + AST + T201)
+      - name: stdio + recorded-session suite
         # PYTHONUNBUFFERED ensures stdout writes from the subprocess
         # under test are flushed to the parent without buffering — we
         # need byte-for-byte determinism on what reaches stdout.
         env:
           PYTHONUNBUFFERED: "1"
-        run: uv run --python 3.12 pytest tests/test_stdio_cleanliness.py -v
+        run: |
+          uv run --python 3.12 pytest \
+            tests/test_stdio_cleanliness.py \
+            tests/test_recorded_sessions.py \
+            -v
 
   fixture-drift-warning:
     name: fixture drift warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,32 @@ jobs:
           PYTHONUNBUFFERED: "1"
         run: uv run --python 3.12 pytest tests/test_stdio_cleanliness.py -v
 
+  fixture-drift-warning:
+    name: fixture drift warning
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    # 3.12 lightweight surface for the fixture-drift policy. When a PR
+    # touches both tests/fixtures/sessions/*.jsonl AND
+    # src/recall/{server,tools}.py, emit a ::warning:: annotation
+    # asking the reviewer to verify fixture changes match the surface
+    # change line-by-line — not rubber-stamp. Doesn't block merge.
+    # Reviewer attention is the weakest enforcement link; this surfaces
+    # the requirement at PR time so it's visible, not just memorial.
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: detect fixture-drift PR
+        run: |
+          base="origin/${{ github.base_ref }}"
+          changed=$(git diff --name-only "$base"...HEAD)
+          fixt=$(echo "$changed" | grep -E '^tests/fixtures/sessions/' || true)
+          surf=$(echo "$changed" | grep -E '^src/recall/(server|tools)\.py$' || true)
+          if [ -n "$fixt" ] && [ -n "$surf" ]; then
+            echo "::warning::Fixture drift detected — both tests/fixtures/sessions/* AND src/recall/{server,tools}.py touched. Reviewer must verify fixture changes match the surface change line-by-line; do not rubber-stamp. See CLAUDE.md §5 'Recorded session fixtures' for the policy."
+          else
+            echo "no fixture drift detected on this PR"
+          fi
+
   scrub-canary:
     name: scrubber test count canary
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,64 @@ follow the same pattern: confirm via the AST check that the file
 isn't on a stdio path, then add a per-file-ignore with a comment
 linking back to this CLAUDE.md section.
 
+**Recorded session fixtures (3.12).** End-to-end MCP protocol
+scenarios live as JSONL files at `tests/fixtures/sessions/*.jsonl`
+and are replayed by `tests/test_recorded_sessions.py` in the same
+`stdio` lane. Where 3.11's stdio cleanliness tests prove the BYTES
+are clean (transport invariant), 3.12's recorded fixtures prove the
+PROTOCOL behaves correctly across multi-frame scenarios that
+single-call subprocess tests can't reach.
+
+Format spec at `tests/fixtures/sessions/_FORMAT.md`. Sentinel
+matching: `<TS>` (any non-negative int), `<HEX16>` (16-char hex),
+`<SCORE>` (float in [-1, 1]), `<INT>` (any int), `<ANY>` (escape
+hatch — warned in CI logs when count > 2 per fixture). Pipelined
+blocks delimited by `#PIPELINE-START` / `#PIPELINE-END` with
+`# tag:<name>` annotations on each frame; the replay engine
+matches expected responses against actual by tag → request id,
+not by arrival order. Tag uniqueness within a block is a format
+constraint enforced by the loader (catches the silent-failure
+mode where someone copy-pastes a fixture line and forgets to
+update the tag).
+
+3.12 ships five scenarios:
+- **S1 long_idle_then_call** — 30s idle then tool call. Asserts
+  (a) SDK stdio handler survives idle. Failure mode: subsequent
+  tools/call returns timeout, malformed response, or server has
+  exited. If failure occurs at exactly 30s with connection error,
+  likely SDK internal idle timeout — investigate.
+- **S2 happy_path** — initialize → tools/list → tools/call recent.
+  The positive case real users walk every session.
+- **S3 error_then_recovery** — validation error doesn't leave the
+  session wedged for the next call.
+- **S4 multiple_back_to_back** — sequential calls preserve state +
+  no per-call resource leak.
+- **S6 pipelined_requests** — id correctness under pipelined sends.
+  Per the 3.12 implementation spike, the mcp SDK currently
+  serializes processing (one in, one out, in send order); this
+  scenario is REGRESSION DEFENSE against future SDK changes that
+  would introduce concurrent dispatch with id-mismatch bugs.
+
+**Fixture drift policy.** When the mcp SDK or recall's tool
+surface changes intentionally, fixtures are hand-edited in the
+SAME commit. Reviewer must verify fixture changes match the
+surface change line-by-line — not rubber-stamp. CI surface: the
+`fixture drift warning` lane emits a `::warning::` annotation on
+PRs that touch both `tests/fixtures/sessions/*.jsonl` AND
+`src/recall/{server,tools}.py`, asking the reviewer to check
+the diff intentionally. Doesn't block merge; surfaces the
+requirement at PR time so it's visible, not just memorial.
+
+**Complementarity with 3.13's manual smoke (forward note).**
+Recorded fixtures are end-to-end protocol verification under
+controlled conditions; 3.13's manual smoke checklist is human-
+eyeball verification across real MCP clients (Claude Desktop,
+Cursor, Zed, Cline) where rendering, tool palette behavior, and
+natural-language summary quality can't be CI-tested. Replay
+catches regressions in the protocol contract; manual smoke
+catches regressions in the user-visible UX. Both surfaces are
+required for v1 launch readiness.
+
 ### 6. Performance budgets (CI-enforced, Phase 3+)
 
 - Cold start (model load + db open): < 2 s on M-series Mac
@@ -1297,6 +1355,37 @@ don't get lost in chat history.
   proves regression prevention, the real-history audit proves
   real-world coverage. Land in the README's privacy / trust
   section at v1 launch. Tag: documentation, phase-4.
+- **Record-mode for fixture authoring (3.12).** Hand-writing
+  recorded session fixtures scales for ≤10 scenarios. If the
+  fixture count grows past ~10, build a record-mode helper that
+  spawns `recall serve`, runs through a documented happy/error
+  path, and dumps the captured frames to a fixture file (with
+  manual sentinel substitution as a follow-up step). Trigger:
+  fixture count in `tests/fixtures/sessions/` exceeds 10. Tag:
+  tech-debt, eval-quality, post-3.12.
+- **Lane split (transport-cleanliness vs protocol-conformance)**
+  — v1.x post-launch. Currently 3.11's stdio cleanliness tests
+  and 3.12's recorded session replay tests share the single
+  `stdio` lane. If the lane wall-clock exceeds 90s on three
+  consecutive runs, evaluate splitting into two lanes:
+  `stdio-cleanliness` (3.11 transport tests) and
+  `protocol-conformance` (3.12 replay tests). Trigger: lane
+  wall-clock > 90s on three consecutive PR or daily runs. Tag:
+  tech-debt, ci, post-launch.
+- **Malformed-frame fixtures.** Recorded session fixtures
+  currently cover only well-formed protocol traffic. If a real
+  MCP client is observed sending malformed frames (user bug
+  report or session log), add a fixture asserting the server's
+  error response. Trigger: at least one observed instance, not
+  theoretical concern. Tag: post-launch, defensive.
+- **Fixture drift PR comment vs lane warning.** 3.12 ships a
+  workflow-level `::warning::` annotation on PRs that touch both
+  fixture and surface files. If reviewer attention proves
+  insufficient (a real fixture-drift bug slips through PR
+  review), upgrade to a PR comment via `gh pr comment` or a
+  required-status-check. Trigger: first observed
+  fixture-drift-slipped-review incident. Tag: ci, defensive,
+  post-launch.
 - **M-series stdio-cleanliness CI** — v1.x post-launch. Requires
   self-hosted M-series runner (or GitHub-hosted ARM macOS runners
   reaching general availability). Target the same cold-cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,71 @@ class MCPSubprocessSession:
         line = await self._read_line(timeout=timeout)
         return json.loads(line)
 
+    # === Generic frame I/O (3.12) ===
+    #
+    # Used by the recorded-session replay engine. The typed helpers above
+    # (initialize / list_tools / call_tool) are convenience wrappers; tests
+    # that play arbitrary recorded fixtures use these instead.
+
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        """Send a JSON-RPC request and return the parsed response.
+
+        The id is allocated internally via the session counter — callers
+        do NOT pass id (per the locked Phase 3.12 §6 decision). Caller-
+        provided ids are a footgun: a bug where fixture authors pick
+        conflicting ids silently breaks request/response pairing under
+        future SDK changes that would otherwise be caught by the
+        pipelined-id-correctness test.
+
+        Returns the response id at the top level so callers (replay
+        engine) can build id-keyed dicts for pipelined matching.
+        """
+        req_id = self._next_id
+        self._next_id += 1
+        frame: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+        if params is not None:
+            frame["params"] = params
+        await self._send(frame)
+        line = await self._read_line(timeout=timeout)
+        return json.loads(line)
+
+    async def send_request_no_wait(self, method: str, params: dict[str, Any] | None = None) -> int:
+        """Send a JSON-RPC request WITHOUT awaiting the response.
+
+        Returns the allocated request id so the caller can correlate the
+        eventual response. Used by the pipelined-request scenario (S6):
+        send N requests, then read N responses, then match by id.
+        """
+        req_id = self._next_id
+        self._next_id += 1
+        frame: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+        if params is not None:
+            frame["params"] = params
+        await self._send(frame)
+        return req_id
+
+    async def send_notification(self, method: str, params: dict[str, Any] | None = None) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        frame: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            frame["params"] = params
+        await self._send(frame)
+
+    async def read_response(self, *, timeout: float = 30.0) -> dict[str, Any]:
+        """Read the next JSON-RPC response without sending anything.
+
+        Used by the pipelined-request scenario after multiple
+        send_request_no_wait() calls.
+        """
+        line = await self._read_line(timeout=timeout)
+        return json.loads(line)
+
     async def close(self) -> None:
         """Close stdin (signals EOF), then wait briefly for graceful exit
         before SIGTERM → SIGKILL escalation."""

--- a/tests/fixtures/sessions/_FORMAT.md
+++ b/tests/fixtures/sessions/_FORMAT.md
@@ -1,0 +1,128 @@
+# Recorded session fixture format (3.12)
+
+This directory holds end-to-end MCP protocol scenarios as JSONL files.
+The replay engine in `tests/test_recorded_sessions.py` walks each
+fixture line-by-line, sending requests, reading responses, and
+matching observed responses against expected ones with sentinel-
+aware comparison.
+
+## File layout
+
+Each fixture is a single `.jsonl` file. One frame per line.
+Lines starting with `#` are comments OR structural directives.
+
+```
+# Scenario: <one-line description>.
+# DB state: <required state>.
+# Lane runtime contribution: <approx>.
+
+> initialize {"protocolVersion":"2024-11-05",...}
+< {"jsonrpc":"2.0","id":<INT>,"result":{...}}
+> notifications/initialized {}
+> tools/call {"name":"recent","arguments":{"limit":3}}
+< {"jsonrpc":"2.0","id":<INT>,"result":{...}}
+```
+
+## Direction markers
+
+- `>` — client → server. Format: `> <method> <params-json>`.
+  Notifications use the same syntax; the loader recognizes
+  `notifications/*` methods and skips the response-read step.
+- `<` — server → client (expected response). Format: `< <full-json>`.
+
+## Comments
+
+Any line starting with `#` is a comment. Comments inside a frame
+position (between `>` lines) are skipped by the loader. The first
+few lines of each file SHOULD document scenario purpose, required
+DB state, and approximate lane runtime contribution.
+
+## Sentinels
+
+Inside `<` frames, certain tokens are sentinels matched loosely:
+
+| sentinel  | matches                                       |
+| --------- | --------------------------------------------- |
+| `<TS>`    | any positive integer (unix-second timestamps) |
+| `<HEX16>` | a 16-char hex string `[0-9a-f]{16}`           |
+| `<SCORE>` | a float in `[-1.0, 1.0]` (cosine similarity)  |
+| `<INT>`   | any integer                                   |
+| `<ANY>`   | any JSON value (escape hatch — see below)     |
+
+Anywhere else, exact equality is enforced.
+
+**`<ANY>` is the escape hatch.** When a fixture has more than 2
+`<ANY>` sentinels, the replay engine emits a pytest warning visible
+in CI logs ("escape-hatch erosion"). It does NOT fail the build —
+the warning surfaces drift toward over-loose fixtures so the
+maintainer can tighten them. Hard cap is intentionally not enforced;
+warning at the right cadence is the discipline.
+
+## Structural directives
+
+Lines beginning with these tokens are parser directives, not frames:
+
+### `#PIPELINE-START` / `#PIPELINE-END`
+
+Marks a pipelined block. Inside the block:
+
+```
+#PIPELINE-START
+> tools/call {"name":"recent","arguments":{"limit":3}}      # tag:recent
+> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}  # tag:stats
+< {"jsonrpc":"2.0","id":<INT>,"result":{...recent shape...}}  # tag:recent
+< {"jsonrpc":"2.0","id":<INT>,"result":{...stats shape...}}   # tag:stats
+#PIPELINE-END
+```
+
+The replay engine:
+1. Sends every `>` frame in the block back-to-back, capturing each
+   request id by its `# tag:<name>` annotation.
+2. Reads N responses (where N = count of `<` frames in the block).
+3. Builds an id-keyed dict of `{id: response}`.
+4. For each expected `<` frame, looks up the request id by tag,
+   then matches the actual response (from the dict) against the
+   expected JSON.
+
+This means **response order is NOT asserted** — id-correctness is.
+That's the protocol contract; in-order arrival is an SDK
+implementation detail.
+
+**Tag uniqueness within a block is a format constraint.** Within
+a single `#PIPELINE-START` / `#PIPELINE-END` block, each tag must
+appear exactly once on a `>` line and exactly once on a `<` line.
+Duplicate tags within a block (e.g. from a copy-paste error) are
+a `FixtureFormatError`. The loader rejects malformed fixtures with
+a clear file:line message.
+
+### `#IDLE <seconds>`
+
+Insert an `await asyncio.sleep(<seconds>)` before the next frame.
+Used by the long-idle scenario (S1) — `#IDLE 30` sleeps 30s before
+the next tool call to verify the SDK stdio handler survives idle.
+
+## Adding a new fixture
+
+1. Create `tests/fixtures/sessions/<scenario_name>.jsonl`.
+2. Write a comment header: scenario purpose, required DB state,
+   lane runtime contribution.
+3. Add a corresponding `test_replay_<scenario_name>` function in
+   `tests/test_recorded_sessions.py`. Each scenario gets its own
+   function so test reports name the failing scenario clearly.
+4. Run `pytest tests/test_recorded_sessions.py -v` locally.
+
+## Fixture drift policy
+
+When the mcp SDK or recall's tool surface changes intentionally,
+fixtures need updating in the same commit as the surface change.
+**Reviewer must verify fixture changes match the surface change
+line-by-line — not rubber-stamp.**
+
+CI surfaces fixture-drift PRs via the `fixture drift warning` lane:
+when a PR touches both `tests/fixtures/sessions/*.jsonl` AND
+`src/recall/{server,tools}.py`, a `::warning::` annotation appears
+on the lane summary asking the reviewer to check the fixture diff
+against the surface change.
+
+If fixture count grows past ~10, revisit with a record-mode tool
+that captures fixtures from a live session (deferred-items entry).

--- a/tests/fixtures/sessions/error_then_recovery.jsonl
+++ b/tests/fixtures/sessions/error_then_recovery.jsonl
@@ -1,0 +1,17 @@
+# Scenario S3: error-then-recovery. After tools/call returns isError=True,
+# the next tools/call must succeed — i.e. one error doesn't leave the
+# session wedged.
+# DB state: 10-row synthetic-vector DB (fixture_indexed_db).
+# Lane runtime contribution: ~0.3s.
+# Format spec: tests/fixtures/sessions/_FORMAT.md.
+
+> initialize {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-subprocess","version":"0.0.1"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"recall-mcp","version":"0.0.1"}}}
+
+> notifications/initialized {}
+
+> tools/call {"name":"command_stats","arguments":{"pattern":"%"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"error":"pattern cannot be bare SQL wildcards (e.g. '%', '%%'); provide a literal substring.","results":[]},"isError":true}}
+
+> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"top_cwds":[["/home/u/proj","<INT>"]],"mean_duration_ms":null,"success_rate":null,"by_source":{"zsh":"<INT>"},"total":"<INT>"},"isError":false}}

--- a/tests/fixtures/sessions/happy_path.jsonl
+++ b/tests/fixtures/sessions/happy_path.jsonl
@@ -1,0 +1,17 @@
+# Scenario S2: happy path. Initialize → notifications/initialized → tools/list → tools/call recent.
+# Tests the positive-case end-to-end flow that real users walk every session.
+# DB state: 10-row synthetic-vector DB (fixture_indexed_db). recent returns
+# the 3 most-recent commands by ts DESC: pytest -xvs (ts=1090), uv sync (1080), make test (1070).
+# Lane runtime contribution: ~0.5s.
+# Format spec: tests/fixtures/sessions/_FORMAT.md.
+
+> initialize {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-subprocess","version":"0.0.1"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"recall-mcp","version":"0.0.1"}}}
+
+> notifications/initialized {}
+
+> tools/list {}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"tools":"<ANY>"}}
+
+> tools/call {"name":"recent","arguments":{"limit":3}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"results":[{"id":"<INT>","text":"pytest -xvs","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null},{"id":"<INT>","text":"uv sync","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null},{"id":"<INT>","text":"make test","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null}]},"isError":false}}

--- a/tests/fixtures/sessions/long_idle_then_call.jsonl
+++ b/tests/fixtures/sessions/long_idle_then_call.jsonl
@@ -1,0 +1,26 @@
+# Scenario S1 (marquee): long idle then tool call. After initialize +
+# initialized, the test sleeps 30s, then issues a tools/call. Asserts:
+#
+#   (a) SDK stdio handler survives idle.
+#
+# 30s rationale: smallest value meaningfully exercising the idle case
+# while keeping the stdio lane under the 90s investigate threshold
+# (CLAUDE.md §6 "Performance budgets"). If real-world idle issues
+# post-launch are 5min+, add a longer scenario via a deferred-items entry.
+#
+# Failure mode: subsequent tools/call returns timeout, malformed
+# response, or server has exited. If failure occurs at exactly 30s with
+# connection error, likely SDK internal idle timeout — investigate.
+#
+# DB state: 10-row synthetic-vector DB (fixture_indexed_db).
+# Lane runtime contribution: ~30s.
+# Format spec: tests/fixtures/sessions/_FORMAT.md.
+
+> initialize {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-subprocess","version":"0.0.1"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"recall-mcp","version":"0.0.1"}}}
+
+> notifications/initialized {}
+
+#IDLE 30
+> tools/call {"name":"recent","arguments":{"limit":1}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"results":[{"id":"<INT>","text":"pytest -xvs","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null}]},"isError":false}}

--- a/tests/fixtures/sessions/multiple_back_to_back.jsonl
+++ b/tests/fixtures/sessions/multiple_back_to_back.jsonl
@@ -1,0 +1,24 @@
+# Scenario S4: multiple back-to-back tools/call. Asserts state is
+# preserved across calls + no per-call resource leak (the response shape
+# stays consistent over N calls; a leak would manifest as truncated
+# results, missing fields, or eventual server-side errors).
+# DB state: 10-row synthetic-vector DB (fixture_indexed_db).
+# Lane runtime contribution: ~0.5s.
+# Format spec: tests/fixtures/sessions/_FORMAT.md.
+
+> initialize {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-subprocess","version":"0.0.1"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"recall-mcp","version":"0.0.1"}}}
+
+> notifications/initialized {}
+
+# Call 1: recent
+> tools/call {"name":"recent","arguments":{"limit":2}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"results":[{"id":"<INT>","text":"pytest -xvs","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null},{"id":"<INT>","text":"uv sync","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null}]},"isError":false}}
+
+# Call 2: command_stats — different shape, same session
+> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"top_cwds":[["/home/u/proj","<INT>"]],"mean_duration_ms":null,"success_rate":null,"by_source":{"zsh":"<INT>"},"total":"<INT>"},"isError":false}}
+
+# Call 3: recent again — must produce same shape as Call 1
+> tools/call {"name":"recent","arguments":{"limit":2}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"results":[{"id":"<INT>","text":"pytest -xvs","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null},{"id":"<INT>","text":"uv sync","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null}]},"isError":false}}

--- a/tests/fixtures/sessions/pipelined_requests.jsonl
+++ b/tests/fixtures/sessions/pipelined_requests.jsonl
@@ -1,0 +1,36 @@
+# Scenario S6: pipelined-request id correctness. Client sends two
+# requests WITHOUT awaiting responses, then collects responses. Replay
+# engine matches each response to its request by id (NOT by arrival
+# position).
+#
+# === SDK behavior (verified at 3.12 implementation spike, 2026-05-08) ===
+# The mcp SDK currently SERIALIZES request processing — one frame in,
+# one response out, in send order. The id-mismatch failure mode this
+# scenario is designed to catch CANNOT OCCUR under the current SDK.
+# This fixture passes trivially TODAY.
+#
+# Role: REGRESSION DEFENSE. If a future SDK release introduces concurrent
+# dispatch (multiple in-flight tool calls), this test would catch any
+# id-pairing bug — i.e. response for request id=A carrying the result
+# meant for id=B. That's the silent-corruption failure mode that would
+# otherwise produce "wrong tool result" symptoms in real MCP clients.
+#
+# In-order arrival is an SDK implementation detail; id-correctness is
+# the protocol contract. This fixture asserts the contract, not the
+# implementation detail.
+#
+# DB state: 10-row synthetic-vector DB (fixture_indexed_db).
+# Lane runtime contribution: ~0.3s.
+# Format spec: tests/fixtures/sessions/_FORMAT.md.
+
+> initialize {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-subprocess","version":"0.0.1"}}
+< {"jsonrpc":"2.0","id":"<INT>","result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"recall-mcp","version":"0.0.1"}}}
+
+> notifications/initialized {}
+
+#PIPELINE-START
+> tools/call {"name":"recent","arguments":{"limit":2}}  # tag:recent
+> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}  # tag:stats
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"results":[{"id":"<INT>","text":"pytest -xvs","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null},{"id":"<INT>","text":"uv sync","text_hash":"<HEX16>","source":"zsh","ts":"<TS>","cwd":"/home/u/proj","hostname":null,"exit_code":null,"duration_ms":null,"session_id":null,"score":null}]},"isError":false}}  # tag:recent
+< {"jsonrpc":"2.0","id":"<INT>","result":{"content":"<ANY>","structuredContent":{"top_cwds":[["/home/u/proj","<INT>"]],"mean_duration_ms":null,"success_rate":null,"by_source":{"zsh":"<INT>"},"total":"<INT>"},"isError":false}}  # tag:stats
+#PIPELINE-END

--- a/tests/manual_smoke.md
+++ b/tests/manual_smoke.md
@@ -32,6 +32,14 @@ The procedure has three sections:
    exist with at least a few hundred rows. Build via `recall index`
    if needed.
 
+<!--
+3.12 cross-reference: the recorded MCP protocol scenarios in
+tests/test_recorded_sessions.py (replaying tests/fixtures/sessions/*.jsonl)
+are the CI-enforced equivalent of Sections A and B. The manual procedure
+below stays as the maintainer's local M-series gate; the replay tests
+catch the same regressions on every PR via the stdio CI lane.
+-->
+
 ## Section A — 3.9-era initialize handshake
 
 Run the following from the repo root:

--- a/tests/test_recorded_sessions.py
+++ b/tests/test_recorded_sessions.py
@@ -1,0 +1,787 @@
+"""Recorded MCP session replay tests (Commit 3.12).
+
+Companion to ``tests/test_stdio_cleanliness.py`` (3.11). Where 3.11
+tests the BYTES are clean (transport invariant), 3.12 tests the
+PROTOCOL behaves correctly across multi-frame scenarios that single-
+call subprocess tests can't reach.
+
+Five scenarios (per the locked Phase 3.12 §4 + refinement):
+  S1 long_idle_then_call  — 30s idle then tool call (marquee)
+  S2 happy_path           — initialize → list → call (positive case)
+  S3 error_then_recovery  — error doesn't wedge subsequent calls
+  S4 multiple_back_to_back — sequential calls preserve state
+  S6 pipelined_requests   — id-correctness under pipelined sends
+
+S5 (state-error then refresh) is NOT included; redundant with 3.11
+test E (covered by lazy-refresh subprocess test).
+
+Format: tests/fixtures/sessions/*.jsonl. Spec lives at
+tests/fixtures/sessions/_FORMAT.md.
+
+Lane: extends the existing ``stdio (ubuntu / py3.12)`` CI lane (3.11).
+3.12 adds ~35s lane runtime (S1's 30s idle + ~5s for S2-S6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+# Sentinel tokens. Documented in tests/fixtures/sessions/_FORMAT.md.
+_SENTINEL_TS = "<TS>"
+_SENTINEL_HEX16 = "<HEX16>"
+_SENTINEL_SCORE = "<SCORE>"
+_SENTINEL_INT = "<INT>"
+_SENTINEL_ANY = "<ANY>"
+_HEX16_RE = re.compile(r"^[0-9a-f]{16}$")
+_TAG_RE = re.compile(r"#\s*tag:([A-Za-z0-9_-]+)")
+
+SESSIONS_DIR = Path(__file__).parent / "fixtures" / "sessions"
+
+_ANY_WARN_THRESHOLD = 2  # warn if a fixture uses <ANY> more than this
+
+
+# === Loader ===
+
+
+class FixtureFormatError(ValueError):
+    """Raised on malformed fixture files. Includes file path + line number
+    + reason in the message."""
+
+
+@dataclass(frozen=True)
+class FixtureFrame:
+    """One frame in a recorded session fixture."""
+
+    direction: Literal[">", "<"]
+    method: str | None  # set for > frames; None for < frames
+    payload: dict[str, Any]  # params for >; full envelope for <
+    tag: str | None  # from "# tag:X" trailing comment, if any
+    line_no: int  # for error messages
+
+    @property
+    def is_notification(self) -> bool:
+        return (
+            self.direction == ">"
+            and self.method is not None
+            and self.method.startswith("notifications/")
+        )
+
+
+@dataclass
+class FixtureScenario:
+    """Parsed scenario: ordered frames + structural directives."""
+
+    path: Path
+    frames: list[FixtureFrame]
+    pipeline_blocks: list[tuple[int, int]]  # half-open [start_idx, end_idx)
+    idle_at: dict[int, int]  # frame_idx → seconds to sleep BEFORE that frame
+    any_count: int = field(default=0)
+
+
+def _strip_inline_comment(s: str) -> tuple[str, str | None]:
+    """Strip an inline ``# tag:X`` annotation; return (head, tag-or-None).
+
+    Only strips ``# tag:NAME`` patterns; other ``#`` content is left intact
+    so JSON containing # in strings doesn't get mangled.
+    """
+    m = _TAG_RE.search(s)
+    if m:
+        return s[: m.start()].rstrip(), m.group(1)
+    return s, None
+
+
+def _parse_request_line(content: str, line_no: int, path: Path) -> tuple[str, dict[str, Any]]:
+    """Parse `> <method> <params-json>` (params-json may be empty)."""
+    parts = content.split(" ", 1)
+    method = parts[0]
+    if len(parts) == 1:
+        params: dict[str, Any] = {}
+    else:
+        try:
+            params = json.loads(parts[1])
+        except json.JSONDecodeError as e:
+            raise FixtureFormatError(
+                f"{path}:{line_no}: invalid JSON params for method {method!r}: {e}"
+            ) from e
+    return method, params
+
+
+def _parse_response_line(content: str, line_no: int, path: Path) -> dict[str, Any]:
+    """Parse `< <full-json>`."""
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as e:
+        raise FixtureFormatError(f"{path}:{line_no}: invalid JSON response: {e}") from e
+    return payload
+
+
+def load_scenario(path: Path) -> FixtureScenario:
+    """Parse a JSONL fixture file. Raises FixtureFormatError on malformed input.
+
+    Fixture validation enforced here:
+      - Tag uniqueness within a pipeline block (one > and one < per tag)
+      - #PIPELINE-START / #PIPELINE-END must be balanced
+      - #IDLE <int> must precede a frame
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"fixture not found: {path}")
+
+    frames: list[FixtureFrame] = []
+    pipeline_blocks: list[tuple[int, int]] = []
+    idle_at: dict[int, int] = {}
+    any_count = 0
+
+    in_pipeline = False
+    pipeline_start_idx = -1
+    pipeline_request_tags: set[str] = set()
+    pipeline_response_tags: set[str] = set()
+    pending_idle: int | None = None
+
+    with path.open(encoding="utf-8") as f:
+        for raw_line_no, raw in enumerate(f, start=1):
+            line = raw.rstrip("\n").rstrip("\r")
+            stripped = line.strip()
+
+            # Empty line: just resets pending_idle? No — keep pending_idle
+            # so blank lines between #IDLE and the frame don't lose it.
+            if not stripped:
+                continue
+
+            # Structural directives
+            if stripped.startswith("#PIPELINE-START"):
+                if in_pipeline:
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: nested #PIPELINE-START not supported"
+                    )
+                in_pipeline = True
+                pipeline_start_idx = len(frames)
+                pipeline_request_tags = set()
+                pipeline_response_tags = set()
+                continue
+
+            if stripped.startswith("#PIPELINE-END"):
+                if not in_pipeline:
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: #PIPELINE-END without matching START"
+                    )
+                # Tag uniqueness: each tag appears exactly once on > and once on <
+                if pipeline_request_tags != pipeline_response_tags:
+                    only_req = pipeline_request_tags - pipeline_response_tags
+                    only_resp = pipeline_response_tags - pipeline_request_tags
+                    msg = []
+                    if only_req:
+                        msg.append(f"request tags without responses: {sorted(only_req)}")
+                    if only_resp:
+                        msg.append(f"response tags without requests: {sorted(only_resp)}")
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: tag mismatch in pipeline block; " + "; ".join(msg)
+                    )
+                pipeline_blocks.append((pipeline_start_idx, len(frames)))
+                in_pipeline = False
+                pipeline_start_idx = -1
+                pipeline_request_tags = set()
+                pipeline_response_tags = set()
+                continue
+
+            if stripped.startswith("#IDLE"):
+                m = re.match(r"^#IDLE\s+(\d+)\s*$", stripped)
+                if not m:
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: malformed #IDLE (expected '#IDLE <seconds>')"
+                    )
+                if pending_idle is not None:
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: consecutive #IDLE "
+                        "directives without intervening frame"
+                    )
+                pending_idle = int(m.group(1))
+                continue
+
+            # Plain comment line — skip
+            if stripped.startswith("#"):
+                continue
+
+            # Frame line: must start with > or <
+            if stripped.startswith(">"):
+                content = stripped[1:].strip()
+                content, tag = _strip_inline_comment(content)
+                if not content:
+                    raise FixtureFormatError(f"{path}:{raw_line_no}: empty request line")
+                method, params = _parse_request_line(content, raw_line_no, path)
+                frame = FixtureFrame(
+                    direction=">",
+                    method=method,
+                    payload=params,
+                    tag=tag,
+                    line_no=raw_line_no,
+                )
+                if in_pipeline:
+                    if tag is None:
+                        raise FixtureFormatError(
+                            f"{path}:{raw_line_no}: pipelined request "
+                            "requires '# tag:<name>' annotation"
+                        )
+                    if tag in pipeline_request_tags:
+                        raise FixtureFormatError(
+                            f"{path}:{raw_line_no}: duplicate tag '{tag}' "
+                            "on pipelined request line "
+                            "(tag uniqueness within a block is required "
+                            "— see _FORMAT.md)"
+                        )
+                    pipeline_request_tags.add(tag)
+                if pending_idle is not None:
+                    idle_at[len(frames)] = pending_idle
+                    pending_idle = None
+                frames.append(frame)
+                continue
+
+            if stripped.startswith("<"):
+                content = stripped[1:].strip()
+                content, tag = _strip_inline_comment(content)
+                if not content:
+                    raise FixtureFormatError(f"{path}:{raw_line_no}: empty response line")
+                payload = _parse_response_line(content, raw_line_no, path)
+                # Count <ANY> sentinels for the warning threshold
+                any_count += _count_any_sentinels(payload)
+                frame = FixtureFrame(
+                    direction="<",
+                    method=None,
+                    payload=payload,
+                    tag=tag,
+                    line_no=raw_line_no,
+                )
+                if in_pipeline:
+                    if tag is None:
+                        raise FixtureFormatError(
+                            f"{path}:{raw_line_no}: pipelined response "
+                            "requires '# tag:<name>' annotation"
+                        )
+                    if tag in pipeline_response_tags:
+                        raise FixtureFormatError(
+                            f"{path}:{raw_line_no}: duplicate tag '{tag}' "
+                            "on pipelined response line "
+                            "(tag uniqueness within a block is required "
+                            "— see _FORMAT.md)"
+                        )
+                    pipeline_response_tags.add(tag)
+                if pending_idle is not None:
+                    # #IDLE before a < doesn't make protocol sense — idle is
+                    # the gap between frames the CLIENT can control.
+                    raise FixtureFormatError(
+                        f"{path}:{raw_line_no}: #IDLE directly before "
+                        "a response line is not supported"
+                    )
+                frames.append(frame)
+                continue
+
+            raise FixtureFormatError(
+                f"{path}:{raw_line_no}: unrecognized line; "
+                f"expected '>', '<', '#', or empty: {stripped!r}"
+            )
+
+    if in_pipeline:
+        raise FixtureFormatError(f"{path}: unclosed #PIPELINE-START at end of file")
+    if pending_idle is not None:
+        raise FixtureFormatError(f"{path}: trailing #IDLE without subsequent frame")
+
+    return FixtureScenario(
+        path=path,
+        frames=frames,
+        pipeline_blocks=pipeline_blocks,
+        idle_at=idle_at,
+        any_count=any_count,
+    )
+
+
+def _count_any_sentinels(value: Any) -> int:
+    """Recursive count of <ANY> sentinel occurrences inside a JSON tree."""
+    if value == _SENTINEL_ANY:
+        return 1
+    if isinstance(value, dict):
+        return sum(_count_any_sentinels(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_count_any_sentinels(v) for v in value)
+    return 0
+
+
+# === Sentinel matcher ===
+
+
+@dataclass
+class MatchFailure:
+    path: str
+    expected_subtree: Any
+    actual_subtree: Any
+
+
+def match_value(expected: Any, actual: Any, *, path: str = "$") -> MatchFailure | None:
+    """Walk expected/actual in parallel; return None on match, MatchFailure on mismatch.
+
+    Sentinel rules:
+      <TS>     → any non-negative int (ts is unix-second; 0 allowed for unknown ts)
+      <HEX16>  → 16-char hex string
+      <SCORE>  → float (or int) in [-1.0, 1.0]
+      <INT>    → any int
+      <ANY>    → matches anything
+      else     → exact equality
+    """
+    if isinstance(expected, str):
+        if expected == _SENTINEL_ANY:
+            return None
+        if expected == _SENTINEL_TS:
+            if isinstance(actual, int) and actual >= 0:
+                return None
+            return MatchFailure(path, "<TS> (non-negative int)", actual)
+        if expected == _SENTINEL_HEX16:
+            if isinstance(actual, str) and _HEX16_RE.match(actual):
+                return None
+            return MatchFailure(path, "<HEX16> (16-char hex string)", actual)
+        if expected == _SENTINEL_SCORE:
+            if isinstance(actual, (int, float)) and -1.0 <= actual <= 1.0:
+                return None
+            return MatchFailure(path, "<SCORE> (float in [-1, 1])", actual)
+        if expected == _SENTINEL_INT:
+            # Booleans are int subclass; reject explicitly.
+            if isinstance(actual, int) and not isinstance(actual, bool):
+                return None
+            return MatchFailure(path, "<INT> (integer)", actual)
+
+    # Dict: same keys + recursive match per key
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            return MatchFailure(path, expected, actual)
+        if set(expected.keys()) != set(actual.keys()):
+            return MatchFailure(
+                path,
+                f"keys={sorted(expected.keys())}",
+                f"keys={sorted(actual.keys())}",
+            )
+        for key in expected:
+            sub = match_value(expected[key], actual[key], path=f"{path}.{key}")
+            if sub is not None:
+                return sub
+        return None
+
+    # List: same length + recursive match per index
+    if isinstance(expected, list):
+        if not isinstance(actual, list):
+            return MatchFailure(path, expected, actual)
+        if len(expected) != len(actual):
+            return MatchFailure(
+                path,
+                f"list of length {len(expected)}",
+                f"list of length {len(actual)}",
+            )
+        for i, (e, a) in enumerate(zip(expected, actual, strict=True)):
+            sub = match_value(e, a, path=f"{path}[{i}]")
+            if sub is not None:
+                return sub
+        return None
+
+    # Scalar: exact equality
+    if expected == actual:
+        return None
+    return MatchFailure(path, expected, actual)
+
+
+def _truncate_json(value: Any, max_chars: int = 400) -> str:
+    """Render value as JSON, truncate to max_chars with ellipsis marker."""
+    s = json.dumps(value, indent=2, default=str)
+    if len(s) <= max_chars:
+        return s
+    return s[:max_chars] + "\n... (truncated)"
+
+
+def _format_failure(fixture_path: Path, frame: FixtureFrame, failure: MatchFailure) -> str:
+    """Side-by-side diff with JSON path + truncated subtrees."""
+    return (
+        f"\n  fixture:        {fixture_path.name}:{frame.line_no}"
+        f"\n  json path:      {failure.path}"
+        f"\n  expected:       {_truncate_json(failure.expected_subtree)}"
+        f"\n  actual:         {_truncate_json(failure.actual_subtree)}"
+    )
+
+
+# === Replay engine ===
+
+
+def _block_containing(blocks: list[tuple[int, int]], idx: int) -> tuple[int, int] | None:
+    for start, end in blocks:
+        if start <= idx < end:
+            return (start, end)
+    return None
+
+
+def _frame_iter_by_block(
+    scenario: FixtureScenario,
+) -> Iterator[tuple[int, FixtureFrame, tuple[int, int] | None]]:
+    """Yield (idx, frame, block) where block is None for non-pipelined frames."""
+    for i, frame in enumerate(scenario.frames):
+        block = _block_containing(scenario.pipeline_blocks, i)
+        yield i, frame, block
+
+
+async def replay(session: Any, scenario: FixtureScenario) -> None:
+    """Walk the scenario; assert protocol conformance.
+
+    Non-pipelined frames: a > frame and its expected < frame are paired
+    by the outer loop; the engine sends the > and matches the actual
+    response against the < (skipping over interleaved notifications).
+
+    Pipelined frames: send all > frames in the block (without awaiting
+    individual responses), read N responses, build id-keyed dict, match
+    each expected < frame against actual by tag → request-id lookup.
+    """
+    # Warn (not fail) if <ANY> count > threshold per locked §3 refinement
+    if scenario.any_count > _ANY_WARN_THRESHOLD:
+        import warnings
+
+        warnings.warn(
+            f"escape-hatch erosion: {scenario.path.name} uses {scenario.any_count} "
+            f"<ANY> sentinels (threshold {_ANY_WARN_THRESHOLD}). "
+            "Tighten fixture by replacing <ANY> with more specific sentinels "
+            "(<TS>, <HEX16>, <SCORE>, <INT>) or exact values where possible.",
+            stacklevel=2,
+        )
+
+    i = 0
+    while i < len(scenario.frames):
+        # Apply any pending idle for this frame index
+        if i in scenario.idle_at:
+            await asyncio.sleep(scenario.idle_at[i])
+
+        block = _block_containing(scenario.pipeline_blocks, i)
+        if block is not None:
+            await _replay_pipeline_block(session, scenario, block)
+            i = block[1]  # skip past block end
+            continue
+
+        frame = scenario.frames[i]
+        if frame.direction == ">":
+            consumed = await _replay_normal_request(session, scenario, frame, i)
+            i += consumed
+            continue
+
+        # frame.direction == "<" outside a pipeline block: this is an
+        # orphan because the matching > should have consumed it. Real
+        # fixture bug.
+        raise FixtureFormatError(
+            f"{scenario.path}:{frame.line_no}: orphaned response line (no preceding request frame)"
+        )
+
+
+async def _replay_normal_request(
+    session: Any,
+    scenario: FixtureScenario,
+    request_frame: FixtureFrame,
+    request_idx: int,
+) -> int:
+    """Handle a non-pipelined > frame. Returns the number of frame
+    indices consumed (1 for notifications, 2+ for request+response).
+    """
+    assert request_frame.method is not None
+
+    if request_frame.is_notification:
+        await session.send_notification(
+            request_frame.method,
+            request_frame.payload if request_frame.payload else None,
+        )
+        # Notification consumes only its own > frame.
+        return 1
+
+    actual = await session.send_request(
+        request_frame.method,
+        request_frame.payload if request_frame.payload else None,
+    )
+
+    # Find the next < frame, skipping over any notifications.
+    response_idx = request_idx + 1
+    while response_idx < len(scenario.frames):
+        f = scenario.frames[response_idx]
+        if f.direction == "<":
+            break
+        if f.direction == ">" and not f.is_notification:
+            # Another request before we found a response — fixture bug.
+            raise FixtureFormatError(
+                f"{scenario.path}:{request_frame.line_no}: request without matching response line"
+            )
+        response_idx += 1
+    else:
+        raise FixtureFormatError(
+            f"{scenario.path}:{request_frame.line_no}: request without matching response line"
+        )
+
+    response_frame = scenario.frames[response_idx]
+    failure = match_value(response_frame.payload, actual)
+    if failure is not None:
+        pytest.fail(
+            f"replay mismatch at request {request_frame.method!r} "
+            f"({scenario.path.name}:{request_frame.line_no})"
+            + _format_failure(scenario.path, response_frame, failure)
+        )
+
+    # Consumed: from request_idx through response_idx inclusive.
+    return response_idx - request_idx + 1
+
+
+async def _replay_pipeline_block(
+    session: Any, scenario: FixtureScenario, block: tuple[int, int]
+) -> None:
+    """Run a pipelined block: send all >; read N responses; match by tag→id."""
+    start, end = block
+    block_frames = scenario.frames[start:end]
+    request_frames = [f for f in block_frames if f.direction == ">"]
+    response_frames = [f for f in block_frames if f.direction == "<"]
+
+    if len(request_frames) != len(response_frames):
+        raise FixtureFormatError(
+            f"{scenario.path}: pipeline block at lines "
+            f"{request_frames[0].line_no}-{response_frames[-1].line_no} "
+            f"has {len(request_frames)} requests but {len(response_frames)} responses"
+        )
+
+    # Send all requests, capture each request id by tag
+    tag_to_request_id: dict[str, int] = {}
+    for req in request_frames:
+        assert req.method is not None
+        assert req.tag is not None  # validated by loader
+        rid = await session.send_request_no_wait(req.method, req.payload if req.payload else None)
+        tag_to_request_id[req.tag] = rid
+
+    # Read N responses; build id-keyed dict
+    id_to_response: dict[int, dict[str, Any]] = {}
+    for _ in request_frames:
+        resp = await session.read_response()
+        rid = resp.get("id")
+        if rid is None:
+            pytest.fail(f"pipelined response missing 'id' field; got: {_truncate_json(resp)}")
+        if rid in id_to_response:
+            pytest.fail(f"duplicate response id {rid} in pipelined block")
+        id_to_response[rid] = resp
+
+    # Match each expected < against actual by tag → request id
+    for resp_frame in response_frames:
+        assert resp_frame.tag is not None
+        if resp_frame.tag not in tag_to_request_id:
+            raise FixtureFormatError(
+                f"{scenario.path}:{resp_frame.line_no}: response tag '{resp_frame.tag}' "
+                "has no matching request tag"
+            )
+        expected_id = tag_to_request_id[resp_frame.tag]
+        if expected_id not in id_to_response:
+            pytest.fail(
+                f"pipelined response with id={expected_id} (tag '{resp_frame.tag}') "
+                f"not received; actual ids: {sorted(id_to_response.keys())}"
+            )
+        actual = id_to_response[expected_id]
+        failure = match_value(resp_frame.payload, actual)
+        if failure is not None:
+            pytest.fail(
+                f"pipelined replay mismatch (tag '{resp_frame.tag}', id={expected_id}) "
+                f"({scenario.path.name}:{resp_frame.line_no})"
+                + _format_failure(scenario.path, resp_frame, failure)
+            )
+
+
+# === Tests ===
+# Each scenario gets its own test function so failures name the broken
+# scenario clearly. DB state setup is inline (per locked §7); fixtures
+# stay focused on protocol contract.
+
+
+@pytest.mark.asyncio
+async def test_replay_happy_path(mcp_subprocess_factory, fixture_indexed_db: Path) -> None:
+    """S2: positive path that real users walk every session."""
+    session = await mcp_subprocess_factory(db_path=fixture_indexed_db)
+    try:
+        scenario = load_scenario(SESSIONS_DIR / "happy_path.jsonl")
+        await replay(session, scenario)
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_error_then_recovery(mcp_subprocess_factory, fixture_indexed_db: Path) -> None:
+    """S3: a failed validation doesn't leave the session wedged."""
+    session = await mcp_subprocess_factory(db_path=fixture_indexed_db)
+    try:
+        scenario = load_scenario(SESSIONS_DIR / "error_then_recovery.jsonl")
+        await replay(session, scenario)
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_multiple_back_to_back(
+    mcp_subprocess_factory, fixture_indexed_db: Path
+) -> None:
+    """S4: sequential calls preserve state; no per-call leak."""
+    session = await mcp_subprocess_factory(db_path=fixture_indexed_db)
+    try:
+        scenario = load_scenario(SESSIONS_DIR / "multiple_back_to_back.jsonl")
+        await replay(session, scenario)
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_pipelined_requests(mcp_subprocess_factory, fixture_indexed_db: Path) -> None:
+    """S6: id-correctness under pipelined sends.
+
+    Per the 3.12 pre-implementation spike: the mcp SDK currently
+    serializes request processing (one in, one out, in send order).
+    The id-mismatch failure mode this scenario is designed to catch
+    cannot occur under current SDK behavior — so this test passes
+    trivially TODAY. Its role is REGRESSION DEFENSE: if a future SDK
+    release introduces concurrent dispatch, the test would catch any
+    id-pairing bug. The fixture's header documents this explicitly.
+    """
+    session = await mcp_subprocess_factory(db_path=fixture_indexed_db)
+    try:
+        scenario = load_scenario(SESSIONS_DIR / "pipelined_requests.jsonl")
+        await replay(session, scenario)
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_long_idle_then_call(mcp_subprocess_factory, fixture_indexed_db: Path) -> None:
+    """S1: (a) SDK stdio handler survives idle.
+
+    Failure mode: subsequent tools/call returns timeout, malformed
+    response, or server has exited. If failure occurs at exactly 30s
+    with connection error, likely SDK internal idle timeout —
+    investigate.
+    """
+    session = await mcp_subprocess_factory(db_path=fixture_indexed_db)
+    try:
+        scenario = load_scenario(SESSIONS_DIR / "long_idle_then_call.jsonl")
+        await replay(session, scenario)
+    finally:
+        await session.close()
+
+
+# === Loader self-tests ===
+# A small handful to catch loader regressions; not full coverage of the
+# fixture format (that's exercised by the scenario tests).
+
+
+def test_loader_rejects_unclosed_pipeline_block(tmp_path: Path) -> None:
+    """Format error: #PIPELINE-START without END."""
+    fp = tmp_path / "bad.jsonl"
+    fp.write_text(
+        '#PIPELINE-START\n> tools/call {"name":"recent","arguments":{"limit":3}}  # tag:a\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(FixtureFormatError, match="unclosed #PIPELINE-START"):
+        load_scenario(fp)
+
+
+def test_loader_rejects_duplicate_tags_in_pipeline_block(tmp_path: Path) -> None:
+    """Format error: duplicate tag within a pipeline block."""
+    fp = tmp_path / "bad.jsonl"
+    fp.write_text(
+        "#PIPELINE-START\n"
+        '> tools/call {"name":"recent","arguments":{"limit":3}}  # tag:dup\n'
+        '> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}  # tag:dup\n'
+        '< {"jsonrpc":"2.0","id":1,"result":{}}  # tag:dup\n'
+        '< {"jsonrpc":"2.0","id":2,"result":{}}  # tag:dup\n'
+        "#PIPELINE-END\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(FixtureFormatError, match="duplicate tag 'dup'"):
+        load_scenario(fp)
+
+
+def test_loader_rejects_pipelined_request_without_tag(tmp_path: Path) -> None:
+    """Format error: pipelined > requires '# tag:<name>' annotation."""
+    fp = tmp_path / "bad.jsonl"
+    fp.write_text(
+        "#PIPELINE-START\n"
+        '> tools/call {"name":"recent","arguments":{"limit":3}}\n'
+        '< {"jsonrpc":"2.0","id":1,"result":{}}  # tag:foo\n'
+        "#PIPELINE-END\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(FixtureFormatError, match="requires '# tag"):
+        load_scenario(fp)
+
+
+def test_loader_rejects_unbalanced_tags(tmp_path: Path) -> None:
+    """Format error: tag on > with no matching < (or vice versa)."""
+    fp = tmp_path / "bad.jsonl"
+    fp.write_text(
+        "#PIPELINE-START\n"
+        '> tools/call {"name":"recent","arguments":{"limit":3}}  # tag:a\n'
+        '> tools/call {"name":"command_stats","arguments":{"pattern":"git"}}  # tag:b\n'
+        '< {"jsonrpc":"2.0","id":1,"result":{}}  # tag:a\n'
+        '< {"jsonrpc":"2.0","id":2,"result":{}}  # tag:c\n'
+        "#PIPELINE-END\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(FixtureFormatError, match="tag mismatch"):
+        load_scenario(fp)
+
+
+def test_loader_parses_idle_directive(tmp_path: Path) -> None:
+    """#IDLE <seconds> attached to the next frame index."""
+    fp = tmp_path / "ok.jsonl"
+    fp.write_text(
+        '> initialize {"protocolVersion":"x"}\n'
+        '< {"jsonrpc":"2.0","id":1,"result":{}}\n'
+        "#IDLE 5\n"
+        '> tools/call {"name":"recent","arguments":{"limit":1}}\n'
+        '< {"jsonrpc":"2.0","id":2,"result":{}}\n',
+        encoding="utf-8",
+    )
+    sc = load_scenario(fp)
+    # The third frame (index 2) is the request after #IDLE 5
+    assert sc.idle_at == {2: 5}
+
+
+def test_matcher_sentinel_TS() -> None:
+    assert match_value(_SENTINEL_TS, 100) is None
+    assert match_value(_SENTINEL_TS, 0) is None
+    assert match_value(_SENTINEL_TS, -1) is not None
+    assert match_value(_SENTINEL_TS, "100") is not None
+
+
+def test_matcher_sentinel_HEX16() -> None:
+    assert match_value(_SENTINEL_HEX16, "0123456789abcdef") is None
+    assert match_value(_SENTINEL_HEX16, "0123") is not None  # too short
+    assert match_value(_SENTINEL_HEX16, "0123456789ABCDEF") is not None  # uppercase
+
+
+def test_matcher_sentinel_SCORE() -> None:
+    assert match_value(_SENTINEL_SCORE, 0.5) is None
+    assert match_value(_SENTINEL_SCORE, 1.0) is None
+    assert match_value(_SENTINEL_SCORE, -1.0) is None
+    assert match_value(_SENTINEL_SCORE, 1.5) is not None
+
+
+def test_matcher_sentinel_INT() -> None:
+    assert match_value(_SENTINEL_INT, 5) is None
+    assert match_value(_SENTINEL_INT, -5) is None
+    assert match_value(_SENTINEL_INT, True) is not None  # booleans rejected
+    assert match_value(_SENTINEL_INT, "5") is not None
+
+
+def test_matcher_sentinel_ANY() -> None:
+    assert match_value(_SENTINEL_ANY, 42) is None
+    assert match_value(_SENTINEL_ANY, "anything") is None
+    assert match_value(_SENTINEL_ANY, {"x": 1}) is None
+
+
+def test_matcher_path_reported_on_mismatch() -> None:
+    """Mismatch failure includes JSON path."""
+    failure = match_value({"a": {"b": 1}}, {"a": {"b": 2}})
+    assert failure is not None
+    assert failure.path == "$.a.b"


### PR DESCRIPTION
## Summary

Commit 3.12 of the locked Phase 3 build: pseudo-client + recorded-session-fixture replay tests. Where 3.11's stdio cleanliness lane proves the BYTES are clean (transport invariant), 3.12's recorded fixtures prove the PROTOCOL behaves correctly across multi-frame scenarios that single-call subprocess tests can't reach.

- **Five scenarios** covering the protocol-conformance surface: long-idle (S1, marquee), happy-path (S2), error-then-recovery (S3), multiple back-to-back (S4), pipelined-request id correctness (S6)
- **JSONL fixture format** with sentinel matching (`<TS>` / `<HEX16>` / `<SCORE>` / `<INT>` / `<ANY>`), pipelined blocks (`#PIPELINE-START` / `#PIPELINE-END` with tag-keyed id matching), and idle directives (`#IDLE <seconds>`)
- **Replay engine** with line-numbered format errors, side-by-side diff on mismatch, escape-hatch warning at >2 `<ANY>` per fixture
- **Conftest extensions**: `send_request` / `send_request_no_wait` / `send_notification` / `read_response` on `MCPSubprocessSession`. id allocated internally — caller-passed ids are a documented footgun.
- **CI surface for fixture drift**: new `fixture drift warning` job emits `::warning::` on PRs touching both fixture files AND `src/recall/{server,tools}.py`

## Highest-value finding: SDK pipelining spike

The locked plan included a 5-min spike on actual SDK pipelining behavior before fixture work. Result:

```
ORDER:        responses arrived in send order (id=2 then id=3)
ID PAIRING:   correct on both responses
TIMING:       both sends in 0.01ms; 2.79ms before first response →
              SDK saw both before responding → processed id=2 first
```

The mcp SDK currently **serializes** request processing. The id-mismatch failure mode S6 catches **cannot occur in current SDK**.

→ S6 is **regression defense** against future SDK changes that introduce concurrent dispatch with id-pairing bugs. Fixture header documents this honestly: "passes trivially today; role is regression defense." Without the spike, S6's documentation would have framed the test inaccurately as actively catching id-mismatch — the spike → honest framing earns reviewer trust.

## Test plan

- [x] `pytest -m "not embed"` — 319 passed in 35.91s (was 303 on main; +16 new tests)
- [x] `pytest -k scrub` — 122 canary clean
- [x] **Combined stdio lane locally**: 22 tests in 54.16s on M-series (well under 90s investigate threshold)
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy src` — 26 files, 0 errors
- [ ] **CI watch**:
  - new replay tests run in expected ~35s (S1's 30s idle dominates)
  - combined stdio lane wall-clock under 90s
  - fixture-drift-warning job runs but emits NO warning (this PR doesn't touch `src/recall/{server,tools}.py`)

## CI on this PR

Expected lanes (10/10):
```
fast (macos × py3.11/3.12/3.13)    pass  ~1m each
fast (ubuntu × py3.11/3.12/3.13)   pass  ~1m each
embed (ubuntu / py3.12)            pass  ~20-23m
stdio (ubuntu / py3.12)            pass  ~50s (3.11 + 3.12 combined)
fixture drift warning              pass  ~10s (no warning emitted)
scrubber test count canary         skip  (scrub.py untouched)
```

## Findings worth flagging

1. **Replay engine bug caught during S2 first-run.** Outer iterator hit `<` frames after consumption by `_replay_normal_request`'s scan-ahead, triggering "orphaned response" errors. Fix: handler returns count of frame indices consumed; outer loop advances by count. Cleaner than tracking a consumed-indices set.
2. **SDK pipelining spike** (above) — informed S6 documentation.
3. **Escape-hatch warning fires correctly on S4** (3 `<ANY>` > threshold 2). Visible in CI logs without breaking the build.
4. **JSON sentinel encoding**: strings (`"<INT>"`, `"<TS>"`), not magic objects. Fixtures parse cleanly with stdlib `json.loads`; matcher recognizes sentinels at leaf-comparison step.

## Files

```
 tests/test_recorded_sessions.py             +787  (NEW)
 tests/fixtures/sessions/_FORMAT.md          +128  (NEW)
 tests/fixtures/sessions/*.jsonl             +120  (NEW; 5 scenarios)
 CLAUDE.md                                   +89   (§5 + 4 deferred entries)
 tests/conftest.py                           +65   (4 generic frame I/O methods)
 .github/workflows/ci.yml                    +26   (fixture-drift-warning job)
 tests/manual_smoke.md                       +8    (cross-ref)
```

No live Claude Desktop smoke needed for 3.12 — server surface unchanged; this is test infrastructure.