### PR TITLE
docs(launch): v1 launch-readiness gate — clients-tested matrix + Windows CI (Commit 3.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,45 @@ jobs:
             echo "no fixture drift detected on this PR"
           fi
 
+  stdio-windows:
+    name: stdio (windows / py3.12)
+    runs-on: windows-latest
+    if: github.event_name != 'schedule'
+    # 3.13 Windows verification gate. Subset of stdio-cleanliness:
+    # initialize-only (A), recent-no-index (C), lazy-refresh (E), AST,
+    # T201. Skips cold-cache (D) — HF/torch Windows-specific behavior
+    # isn't stdio-cleanliness territory; would surface as "is torch
+    # working on Windows" rather than "are we leaking stdout."
+    #
+    # Locked Phase 3.13 F1: combined approach. CI Windows lane is
+    # permanent; manual MCP-client UX verification on Windows happens
+    # pre-launch via UTM VM session (filled into docs/clients-tested.md).
+    #
+    # Triage rule for failures (CLAUDE.md "Windows test triage"):
+    #   - Test fails in recall code path AND non-Windows lanes pass:
+    #     real Windows bug; block 3.13 until fixed.
+    #   - Test fails in subprocess/pipe handling AND non-Windows lanes
+    #     pass: classify as Windows test-infra quirk; mark
+    #     pytest.skip(reason=..., platform=='win32'); document in
+    #     CLAUDE.md; file v1.x deferred entry; ship 3.13 without the
+    #     failing Windows test.
+    #   - Unclear cause: investigate before deciding. Don't ship with
+    #     unclear Windows state.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: install python 3.12
+        run: uv python install 3.12
+      - name: sync deps
+        run: uv sync --python 3.12
+      - name: stdio subset (no cold-cache)
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          uv run --python 3.12 pytest tests/test_stdio_cleanliness.py -v -k "not cold_cache"
+
   scrub-canary:
     name: scrubber test count canary
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1453,6 +1453,19 @@ don't get lost in chat history.
   proves regression prevention, the real-history audit proves
   real-world coverage. Land in the README's privacy / trust
   section at v1 launch. Tag: documentation, phase-4.
+- **README v1: explicit "rich UX requires atuin" framing** — Phase
+  4 README content. Surfaced at 3.13's clients-tested matrix
+  verification: zsh/bash readers don't capture cwd, hostname,
+  exit_code, duration_ms, or session_id (atuin captures all of
+  them). Two tools (`commands_after`, `failed_recently`) require
+  atuin's session-tracking + exit-code data to function; the
+  semantic-search core works without atuin. Frame in README as
+  value-add: "atuin integration enables richest UX; without it,
+  semantic search + frequency analytics still work fully."
+  Familiar "install X for full experience" pattern. NOT a bug —
+  honest limitation that the README needs to surface upfront so
+  drive-by visitors understand the install matrix before they
+  install. Tag: documentation, phase-4.
 - **Record-mode for fixture authoring (3.12).** Hand-writing
   recorded session fixtures scales for ≤10 scenarios. If the
   fixture count grows past ~10, build a record-mode helper that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1523,6 +1523,20 @@ don't get lost in chat history.
   content. Add CI badge to README so HN visitors can see the
   invariant is enforced (the trust story). Tag: documentation,
   phase-4.
+- **macOS desktop client matrix expansion (v1.0.1).** v1 ships
+  with `docs/clients-tested.md` containing 1/6 filled entries
+  (Claude.ai web MCP connector). The 4 macOS desktop/IDE clients
+  (Cursor, Claude Desktop, Zed, Cline VS Code) and 1 Windows entry
+  are explicitly `not yet verified` — Section C is human-eyeball
+  work the v1 launch sprint isn't budgeting time for. The
+  Claude.ai web entry IS load-bearing (it surfaced findings
+  F1-F5; provides the v1 README's trust signal). v1.0.1 task:
+  run Section C against the 4 macOS clients in the locked §9
+  order (Cursor → Claude Desktop → Zed → Cline) and fill entries
+  with real observations. UTM VM Windows session as a separate
+  v1.0.1 sub-task. This decision was the 2026-05-10 launch-sprint
+  trade-off: 1/6 honest > 6/6 aspirational. Tag:
+  v1.0.1-launch-followup, documentation.
 - **clients-tested.md staleness policy when client major-versions
   update** — v1.x post-launch. Each entry in `docs/clients-tested.md`
   records the client version at last verification. When a client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1474,6 +1474,23 @@ don't get lost in chat history.
   manual sentinel substitution as a follow-up step). Trigger:
   fixture count in `tests/fixtures/sessions/` exceeds 10. Tag:
   tech-debt, eval-quality, post-3.12.
+- **Concurrent-dispatch handler invariants (3.12 §4 follow-up).**
+  The 3.12 §4 decision skipped concurrency in recorded fixtures on
+  the assumption that MCP stdio's single-thread transport made it
+  irrelevant. The 2026-05-10 F5 diagnostic spike confirmed dispatch
+  IS concurrent at the asyncio layer — handlers interleave. The
+  original concern (long-call queues short-call) was refuted; the
+  inverted concern is real: handlers must remain correct under
+  interleaved execution. v1's handlers are read-only against shared
+  state with `_embedder_lock` for the one mutation, so v1 is
+  correct. Future tools mutating shared state (cache invalidation,
+  runtime config changes, indexer-while-server scenarios beyond
+  the documented "unsupported" framing) need explicit concurrent-
+  dispatch race testing. Concrete addition when triggered: recorded
+  fixture exercising "long-call in flight, short call dispatched
+  concurrently — short call's response arrives in expected wall-
+  clock window AND reflects consistent shared-state snapshot." Tag:
+  tech-debt, eval-quality, post-3.13.5.
 - **Lane split (transport-cleanliness vs protocol-conformance)**
   — v1.x post-launch. Currently 3.11's stdio cleanliness tests
   and 3.12's recorded session replay tests share the single

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,31 @@ follow the same pattern: confirm via the AST check that the file
 isn't on a stdio path, then add a per-file-ignore with a comment
 linking back to this CLAUDE.md section.
 
+**Windows stdio lane (3.13).** A `stdio-windows` job on
+`windows-latest` runs the A+C+E+AST+T201 subset of the stdio
+cleanliness suite. Cold-cache test D is excluded — HF/torch
+Windows-specific behavior isn't stdio-cleanliness territory; would
+surface as "is torch working on Windows" rather than "are we leaking
+stdout." Windows MCP-client UX verification happens manually via
+the UTM VM session (CLAUDE.md "v1 launch-readiness gate (3.13)").
+
+**Windows test triage rule.** When a test fails on the
+`stdio-windows` lane:
+  - **Test fails in recall code path AND non-Windows lanes pass:**
+    real Windows bug. Block 3.13 (or whatever commit surfaced it)
+    until fixed.
+  - **Test fails in subprocess/pipe handling AND non-Windows lanes
+    pass:** classify as Windows test-infrastructure quirk (POSIX vs
+    Windows pipe semantics differ). Mark
+    `pytest.skip(reason="...", platform=='win32')` for that specific
+    test, document the reason in CLAUDE.md, file a v1.x deferred-
+    items entry, ship without the failing Windows test.
+  - **Unclear cause:** investigate to reach one of the above
+    categories before deciding. Don't ship with unclear Windows
+    state.
+  This decision tree was locked at 3.13 plan; future contributors
+  inherit the same triage rather than improvising under pressure.
+
 **Recorded session fixtures (3.12).** End-to-end MCP protocol
 scenarios live as JSONL files at `tests/fixtures/sessions/*.jsonl`
 and are replayed by `tests/test_recorded_sessions.py` in the same
@@ -1193,6 +1218,79 @@ When adding a new tool: pick the closest existing class. New error
 classes need a new row here AND a corresponding handler in
 `recall.tools.dispatch_tool`.
 
+## v1 launch-readiness gate (3.13)
+
+3.13 closes Phase 3 and gates the v1 announce. Two surfaces:
+
+**1. Stdio Windows CI lane (`stdio-windows`).** Permanent gate
+running on `windows-latest`, py3.12. Subset of stdio cleanliness
+tests: A initialize-only, C tools/call recent (no-index dispatch),
+E lazy-refresh subprocess, AST check, T201. Cold-cache D excluded
+per CLAUDE.md §5 "Windows stdio lane (3.13)".
+
+**2. Per-client UX verification matrix** at `docs/clients-tested.md`.
+Five entries: 4 macOS (Cursor, Claude Desktop, Zed, Cline VS Code)
++ 1 Windows (Claude Desktop via UTM VM). Each entry captures the
+7-item assertion-checklist outcome from `tests/manual_smoke.md`
+Section C, free-text observations including natural-language
+summary quality from the client's LLM, and a "Known issues"
+subsection that accumulates the v1.x punch list naturally.
+
+The procedure file (`tests/manual_smoke.md` Section C) says HOW
+to verify; the matrix file (`docs/clients-tested.md`) says WHAT
+was observed when each client was last verified. Different
+artifacts with different update cadences — don't conflate.
+
+### Cadence
+
+Re-verify `docs/clients-tested.md` entries when:
+1. Major recall version change (v1.0 → v1.1 → v2.0)
+2. Recall PR touches user-facing surface (tool descriptions,
+   output structure, error messages) — reviewer flags
+3. Client major version update (e.g. Claude Desktop 1 → 2).
+   Maintainer monitors manually for v1; automated tracking is
+   a v1.x deferred-items entry.
+
+### v1 launch-readiness contract
+
+Before v1 announce:
+
+- All entries in `docs/clients-tested.md` filled with **real
+  observations** — not placeholder text. Shipping `1/4 honestly`
+  with a README caveat is preferred over `4/4 carelessly`.
+  Maintainer fatigue or session limits are valid reasons to leave
+  an entry as `not yet verified`; fabricated observations are not.
+- `stdio-windows` CI lane green on main.
+- All Phase 3 commits (3.9-3.13) on main with green CI.
+
+### Pre-launch UTM VM session (Windows)
+
+Setup: install [UTM](https://mac.getutm.app/) (free, Apple Silicon
+native), download Microsoft's free Windows 11 ARM development VM,
+install Claude Desktop for Windows. Estimated 2-3 hour focused
+session. Fills the Windows entry in `docs/clients-tested.md`.
+
+If serious Windows-specific bugs surface during the session,
+document in "Known issues" + file as v1.x post-launch deferred
+items unless security-relevant. Don't block v1 launch on cosmetic
+Windows quirks.
+
+### Phase 4 boundary
+
+3.13 produces `docs/clients-tested.md`. Phase 4 quotes from it
+into the README's "Tested clients" table; adds CI status badges;
+writes the launch-day install/usage docs. 3.13 does NOT update
+the README itself; the README is Phase 4 owner.
+
+### Section C reframe (manual_smoke.md)
+
+`tests/manual_smoke.md` Section C was originally framed as
+"live MCP-client smoke (Claude Desktop)" at 3.10. 3.13 reframes
+it as "live MCP-client smoke (any client)" — the canonical
+procedure each client in the matrix runs through. The 7-item
+assertion-checklist + the natural-language-summary observation
+step live in Section C; outcomes flow into `docs/clients-tested.md`.
+
 ## Deferred items (file as GitHub issues at end of Phase 1)
 
 These were called out and intentionally deferred. File them as GitHub
@@ -1395,12 +1493,15 @@ don't get lost in chat history.
   content. Add CI badge to README so HN visitors can see the
   invariant is enforced (the trust story). Tag: documentation,
   phase-4.
-- **v1.0 launch checklist: cold-cache subprocess test on local
-  M-series Mac.** Run before announce; append result to
-  docs/clients-tested.md (lands in Commit 3.13). The Linux-only
-  CI gate is sufficient for catch-on-PR; M-series adds confidence
-  that MPS warmup messages don't leak. Tag: v1-launch-blocker,
-  must-do-before-announce.
+- **clients-tested.md staleness policy when client major-versions
+  update** — v1.x post-launch. Each entry in `docs/clients-tested.md`
+  records the client version at last verification. When a client
+  ships a major version update (e.g. Claude Desktop 1 → 2), the
+  matching entry is potentially stale (UI rewrite, MCP integration
+  changes, etc.). v1 relies on maintainer manual monitoring; v1.x
+  could automate (e.g. periodic re-verification reminder, or
+  semver-aware staleness flag in the README's "Tested clients"
+  table). Tag: documentation, post-v1.
 - **Refactor `src/recall/indexer.py` `print(..., file=sys.stderr)`
   calls to use logging.** Phase 4 polish, low priority. Currently
   the indexer's user-facing progress lines (during `recall index`

--- a/docs/clients-tested.md
+++ b/docs/clients-tested.md
@@ -1,0 +1,224 @@
+# clients-tested.md
+
+Per-client verification matrix for `recall-mcp`. Each entry captures:
+client+OS+recall versions, date verified, the 7-item assertion-
+checklist outcome from [`tests/manual_smoke.md`](../tests/manual_smoke.md)
+Section C, free-text observations (including natural-language summary
+quality from the client's LLM), and any known issues.
+
+This file is the *evidence* file. The *procedure* lives at
+[`tests/manual_smoke.md`](../tests/manual_smoke.md) Section C —
+HOW to verify; this file records WHAT was observed.
+
+The README's "Tested clients" table (added in Phase 4) quotes from
+this file directly.
+
+## Glossary
+
+| symbol  | meaning                                                                |
+| ------- | ---------------------------------------------------------------------- |
+| pass    | assertion held in the maintainer's session                             |
+| skip    | not applicable to this client (e.g. tool palette UI absent)            |
+| fail    | assertion did not hold; details in the entry's "Known Issues" section  |
+| —       | not yet verified (entry pending; see launch-readiness contract below)  |
+
+## Cadence
+
+Re-verify each entry when:
+
+1. **Major recall version change** (v1.0 → v1.1 → v2.0)
+2. **Recall PR touches user-facing surface** — tool descriptions,
+   output structure, error messages. Reviewer flags the PR as
+   needing client re-verification.
+3. **Client major version update** (e.g. Claude Desktop 1 → 2). Maintainer
+   monitors manually for v1; automated tracking is a v1.x deferred item.
+
+## v1 launch-readiness contract
+
+Before v1 announce:
+
+- All entries below filled with **real observations** — not placeholder
+  text. If an entry hasn't been verified yet, leave it as `—` (not
+  yet verified). Shipping `1/4 honestly` with a README caveat is
+  preferred over `4/4 carelessly` (CLAUDE.md "v1 launch-readiness
+  gate (3.13)").
+- `stdio-windows` CI lane green on main.
+- All Phase 3 commits (3.9-3.13) on main with green CI.
+
+---
+
+## Cursor (macOS)
+
+| field           | value |
+| --------------- | ----- |
+| Client version  | _not yet verified_ |
+| OS version      | _not yet verified_ |
+| Recall version  | 0.0.1 |
+| Date verified   | _not yet verified_ |
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools in palette                                      | —      |
+| 2 | tool descriptions render fully (or noted truncation)                           | —      |
+| 3 | tools/call recent succeeds + renders readably                                  | —      |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | —      |
+| 5 | tools/call search triggers embedder load; client shows progress (no frozen UI) | —      |
+| 6 | no tracebacks visible to user                                                  | —      |
+| 7 | recall.log shows structured `tool=<name>` lines                                | —      |
+
+### Observations
+
+_(maintainer fills in — natural-language summary quality from the
+client's LLM, rendering quirks, latency notes, anything notably good
+or notably bad)_
+
+### Known issues
+
+- (none yet — fill bullet list as observations accumulate)
+
+---
+
+## Claude Desktop (macOS)
+
+| field           | value |
+| --------------- | ----- |
+| Client version  | _not yet verified_ |
+| OS version      | _not yet verified_ |
+| Recall version  | 0.0.1 |
+| Date verified   | _not yet verified_ |
+
+> Pre-3.13 reference: a partial Claude Desktop verification was run
+> at the 3.10 squash-merge gate. Result: tools/list rendered all 6
+> tools; the `recent` tool's no-index error rendered as natural-
+> language guidance; refresh transition (3.10 follow-up) verified
+> end-to-end. That session predates the canonical 7-item checklist;
+> formalized re-verification fills the entry below.
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools in palette                                      | —      |
+| 2 | tool descriptions render fully (or noted truncation)                           | —      |
+| 3 | tools/call recent succeeds + renders readably                                  | —      |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | —      |
+| 5 | tools/call search triggers embedder load; client shows progress (no frozen UI) | —      |
+| 6 | no tracebacks visible to user                                                  | —      |
+| 7 | recall.log shows structured `tool=<name>` lines                                | —      |
+
+### Observations
+
+_(maintainer fills in — natural-language summary quality from the
+client's LLM, rendering quirks, latency notes, anything notably good
+or notably bad)_
+
+### Known issues
+
+- (none yet)
+
+---
+
+## Zed (macOS)
+
+| field           | value |
+| --------------- | ----- |
+| Client version  | _not yet verified_ |
+| OS version      | _not yet verified_ |
+| Recall version  | 0.0.1 |
+| Date verified   | _not yet verified_ |
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools in palette                                      | —      |
+| 2 | tool descriptions render fully (or noted truncation)                           | —      |
+| 3 | tools/call recent succeeds + renders readably                                  | —      |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | —      |
+| 5 | tools/call search triggers embedder load; client shows progress (no frozen UI) | —      |
+| 6 | no tracebacks visible to user                                                  | —      |
+| 7 | recall.log shows structured `tool=<name>` lines                                | —      |
+
+### Observations
+
+_(maintainer fills in)_
+
+### Known issues
+
+- (none yet)
+
+---
+
+## Cline VS Code (macOS)
+
+| field           | value |
+| --------------- | ----- |
+| Client version  | _not yet verified_ |
+| OS version      | _not yet verified_ |
+| Recall version  | 0.0.1 |
+| Date verified   | _not yet verified_ |
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools in palette                                      | —      |
+| 2 | tool descriptions render fully (or noted truncation)                           | —      |
+| 3 | tools/call recent succeeds + renders readably                                  | —      |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | —      |
+| 5 | tools/call search triggers embedder load; client shows progress (no frozen UI) | —      |
+| 6 | no tracebacks visible to user                                                  | —      |
+| 7 | recall.log shows structured `tool=<name>` lines                                | —      |
+
+### Observations
+
+_(maintainer fills in)_
+
+### Known issues
+
+- (none yet)
+
+---
+
+## Claude Desktop (Windows 11 ARM, UTM VM)
+
+| field           | value |
+| --------------- | ----- |
+| Client version  | _not yet verified — pre-launch UTM VM session_ |
+| OS version      | _Windows 11 ARM (UTM VM on Apple Silicon)_ |
+| Recall version  | 0.0.1 |
+| Date verified   | _not yet verified_ |
+
+> Setup notes for the maintainer: install [UTM](https://mac.getutm.app/)
+> (free, Apple Silicon native), download Microsoft's free [Windows 11
+> ARM development VM](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/),
+> install Claude Desktop for Windows, install recall via `pip install -e .`
+> from the cloned repo (uvx flow may not be available out-of-the-box).
+>
+> Permanent CI gate for Windows stdio-cleanliness lives in the
+> `stdio-windows` CI lane (3.13). This manual entry covers the UX
+> dimensions CI can't reach: Claude Desktop's Windows-specific
+> rendering, tool palette behavior on Windows, MCP config file
+> location (`%APPDATA%\Claude\claude_desktop_config.json`).
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools in palette                                      | —      |
+| 2 | tool descriptions render fully (or noted truncation)                           | —      |
+| 3 | tools/call recent succeeds + renders readably                                  | —      |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | —      |
+| 5 | tools/call search triggers embedder load; client shows progress (no frozen UI) | —      |
+| 6 | no tracebacks visible to user                                                  | —      |
+| 7 | recall.log shows structured `tool=<name>` lines                                | —      |
+
+### Observations
+
+_(maintainer fills in pre-launch via UTM VM session)_
+
+### Known issues
+
+- (none yet)

--- a/docs/clients-tested.md
+++ b/docs/clients-tested.md
@@ -94,31 +94,42 @@ trustworthiness; conflating sessions corrupts that.
 
 **Cost:** ~10 LoC + 1 fixture update + tool description tweak.
 
-### F2 — only 4 of 6 tools registered in MCP client
+### F2 — `find_in_project` not appearing in client tool palette (5/6 visible)
 
-**Symptom:** `recent` and `failed_recently` not appearing in the
-client's tool palette. Other 4 tools (search, find_in_project,
-commands_after, command_stats) appear normally.
+**Symptom:** Out of the 6 registered tools, 5 appear in the Claude.ai
+MCP connector's tool palette: `search`, `commands_after`,
+`failed_recently`, `command_stats`, `recent`. **`find_in_project`
+specifically is missing.** Original 3.13 framing of this finding
+("only 4/6 visible") was wrong; updated observation has 5/6 visible
+with `find_in_project` as the lone holdout.
 
-**Hypothesis:** The 4 visible tools all have at least one required
-parameter (`query` or `pattern`); the 2 missing tools have no
-required parameters (all fields default or nullable). Pydantic v2's
-`model_json_schema()` **omits the `"required"` key entirely when
-no fields are required** (vs emitting `"required": []`). Some MCP
-clients filter or hide tools whose schema lacks a `required`
-declaration.
+**Earlier hypothesis refuted.** The "missing required-key" hypothesis
+applied to tools with no required parameters; `find_in_project` HAS
+a required parameter (`query`), so that hypothesis can't explain why
+it specifically is filtered.
 
-**Verification needed before fix (3.13.5 plan should include):**
-1. Capture actual tools/list JSON from a fresh Claude Desktop session
-   against current main; compare to 3.10 manual smoke baseline.
+**Open hypothesis space (none confirmed):**
+1. Client treats `find_in_project` as a duplicate/subset of `search`
+   (overlapping semantic surface; both take `query` + an optional
+   path filter) and dedups one.
+2. Description content trips a content filter (mentions environment
+   variable `MCP_CLIENT_CWD`, mentions filesystem paths).
+3. Position 2 in TOOLS list interacts with a client UI heuristic.
+
+**Verification needed (3.13.5 plan):**
+1. Capture actual `tools/list` JSON the Claude.ai MCP connector
+   received; compare to 3.10 manual smoke baseline schema for
+   `find_in_project`.
 2. Test the same recall server against one other MCP client (Cursor
-   or Zed). If `recent`/`failed_recently` appear there → Claude.ai
-   MCP connector-specific filtering, fix framed as "compatibility
-   shim." If they don't appear in any client → JSON Schema convention
-   issue, fix framed as "spec compliance."
+   or Zed). If `find_in_project` appears there → Claude.ai-connector-
+   specific filtering. If it doesn't appear in any client → some
+   shape of our tool registration is incompatible.
 
-**Fix path (3.13.5) — same regardless of root cause:**
-3-line `setdefault("required", [])` in `_tool_for()`:
+**Fix path (3.13.5) — baseline + investigation:**
+
+Apply the original 3-line `setdefault("required", [])` shim in
+`_tool_for()` regardless. Doesn't change semantics; makes schemas
+explicit; helps any client that filters on missing-required-key:
 
 ```python
 def _tool_for(name, description, model):
@@ -127,10 +138,112 @@ def _tool_for(name, description, model):
     return Tool(name=name, description=description, inputSchema=schema)
 ```
 
-Doesn't change semantics; makes the schema explicit. Backwards-
-compatible with clients that already work.
+**This shim is unlikely to be the load-bearing fix for find_in_project
+specifically** (its schema already has `"required": ["query"]`). The
+investigation step above identifies the real cause; the fix shape
+adjusts based on outcome (description rewording, schema tweak, or
+filing as upstream client bug).
 
-### Per-client cross-reference
+**Cost:** ~3 LoC for the shim + ~30 min investigation effort + fix
+shape TBD. Probably ~10-30 LoC total.
+
+### F4 — `recent` returns wrong-order data on zsh-only indexes
+
+**Symptom:** `recent` (the canonical "show me my most recent
+commands" tool) returns OLDEST-first commands when the index is
+zsh-only. Tool description claims "Time-ordered DESC, id ASC
+tie-break"; actual behavior contradicts the description silently.
+
+**Root cause:** zsh's `EXTENDED_HISTORY` flag is not always set;
+when absent, the zsh source emits entries with `ts = 0` (unknown
+timestamp, per HistorySource protocol). With `ts` uniformly 0
+across the result set, the tie-break (`id ASC`) dominates →
+oldest-insertion-first. Same silent-degradation shape as F1
+(commands_after): tool succeeds, returns data, but data doesn't
+match documented semantics.
+
+**Fix path (3.13.5):** Hybrid ORDER BY in `_handle_recent`. When
+`ts` is known (>0), use it; when unknown (=0), fall back to
+insertion order (`id DESC`) as a time-proxy:
+
+```sql
+ORDER BY
+  CASE WHEN ts > 0 THEN 0 ELSE 1 END,  -- real-ts rows first
+  ts DESC,
+  id DESC                              -- fallback: most-recent insertion first
+```
+
+This treats `ts = 0` as "unknown timestamp; use insertion order"
+rather than as "literally epoch-zero." Mixed-source indexes
+(atuin + zsh, where atuin has real `ts` and zsh has 0) get
+atuin rows first by ts, then zsh rows by id-descending — both
+groups in most-recent-first order.
+
+**Why not atuin-required (parallel to F1)?** `recent` is the most
+basic tool — "show me my history." Forcing atuin for it is too
+aggressive for v1. `id DESC` is a correctness-preserving fallback
+(insertion order is ~time order for shell history) without the
+cross-session-conflation risk that ruled out the heuristic for
+`commands_after` (where the question is causal: "what came after
+X").
+
+**Same fix applies anywhere we order by `ts`.** Other handlers
+(`commands_after` post-F1-fix, `failed_recently`) can use the
+same pattern; v1 only `recent` needs it for non-atuin users.
+
+**Cost:** ~5 LoC (SQL change) + 1-2 fixture updates + tool
+description tweak.
+
+### F5 — `failed_recently` 4+ minute hang (observed once, monitoring)
+
+**Symptom (single observation):** During a Claude.ai MCP connector
+session that had previously made multiple semantic search calls
+against an indexed corpus, `failed_recently` against a non-atuin
+index hung for 4+ minutes. Claude.ai's connector emitted a "MCP
+server may be crashed" timeout warning. Re-running the same call
+against the same index returned the clean state-error in ~8ms.
+
+**Original hypothesis (asyncio dispatch serialization) — REFUTED.**
+Diagnostic spike (2026-05-10) confirmed: SDK dispatch is concurrent.
+Fired `failed_recently` 50ms after a cold-cache `search` (24-second
+model load); `failed_recently` returned a clean state-error in 8ms
+while `search` was still 24 seconds away from completing. Recall log
+captured both handler dispatches in the same wall-clock second:
+
+```
+09:58:06 INFO recall.server: lazy-loading embedder (first tool call)
+09:58:06 INFO recall.server.tools tool=failed_recently state_error count=0
+09:58:30 INFO recall.server: embedder ready (model=BAAI/bge-small-en-v1.5, dim=384)
+09:58:30 INFO recall.server.tools tool=search ok count=3
+```
+
+Asyncio scheduling correctly interleaves handlers; the embedder
+lock doesn't block unrelated tool calls; the SDK does NOT serialize
+at the dispatch layer (despite serializing in the simple two-fast-
+handler case from the 3.12 spike).
+
+**Hypothesis space remaining (none confirmed):**
+- Claude.ai MCP connector-specific behavior under load (transport
+  framing, request batching, network-side retry)
+- Transient OS-level pipe stall
+- Network/transport-level glitch specific to that session
+
+**Status: monitoring. No code fix to ship.** Without reproduction,
+there's no fix to verify. Cannot ship a fix against an unreproducible
+bug — would have no way to know if the fix worked.
+
+**User feedback channel for v1.0.1:** if this recurs, we want
+diagnostic data to investigate. **If you encounter this:**
+
+1. File a GitHub issue with the contents of `~/.recall/logs/recall.log`
+   from the affected session (timestamp window around the hang).
+2. If you can reproduce it: `py-spy dump --pid $(pgrep -f 'recall serve')`
+   while the hang is in progress and attach the stack trace.
+3. Note the client (Claude.ai web, Claude Desktop, Cursor, etc.) and
+   what tool calls preceded the hang in the same session.
+
+This converts F5 from launch-blocker into a v1.0.1 user-feedback
+channel.
 
 Each client's "Known Issues" subsection below cross-references this
 "Pending fixes (3.13.5)" section rather than restating the findings.
@@ -147,6 +260,71 @@ add: "atuin integration enables richest UX; without it, semantic
 search + frequency analytics still work fully." Familiar
 "install X for full experience" pattern. Tracked as Phase 4
 deferred entry in CLAUDE.md.
+
+---
+
+## Claude.ai web (MCP connector) — first filled-in entry
+
+| field           | value |
+| --------------- | ----- |
+| Client          | Claude.ai web app, MCP connector surface |
+| Client version  | (web app — version N/A; verified against then-current production) |
+| OS              | N/A (browser-based; Claude.ai's connector is the MCP host) |
+| Recall version  | verify/3.13 @ commit `43d652b` (3.13 + evidence trail) |
+| Date verified   | 2026-05-09 — 2026-05-10 (multi-session verification surfaced F1, F2, F4, F5) |
+
+**Important framing**: this entry uses Claude.ai's MCP connector — a
+web-app surface, not a desktop tool palette. Verification done via
+AI assistant intermediating tool calls; **rendering and natural-
+language summary observations are N/A for this client surface** — the
+MCP connector returns structured data to Claude.ai, which the
+assistant LLM may further summarize, but there's no end-user "tool
+palette" UI to evaluate the way Claude Desktop, Cursor, Zed, or Cline
+have.
+
+This entry's value is its role as the **bug-surfacing surface**. The
+verification session against this client is what produced findings
+F1-F5 listed in "Pending fixes (3.13.5)" above. Subsequent macOS
+clients (Cursor, Claude Desktop, Zed, Cline) verify the UX dimensions
+that don't apply here.
+
+### Assertion checklist
+
+| # | check                                                                          | result |
+| - | ------------------------------------------------------------------------------ | ------ |
+| 1 | tools/list renders all 6 tools                                                 | **fail** — 5/6 visible; `find_in_project` missing (see F2) |
+| 2 | tool descriptions render fully                                                 | pass (visible tools' descriptions rendered fully in the assistant's tool-discovery context) |
+| 3 | tools/call recent succeeds + renders readably                                  | **fail** — succeeds but returns wrong-order data on zsh-only index (see F4) |
+| 4 | tools/call command_stats `pattern: "%"` returns clean user-facing error       | pass — clean validation error text returned in milliseconds |
+| 5 | tools/call search triggers embedder load; client shows progress                | pass — verified via 2026-05-10 spike: 24s cold-cache load, no frozen state |
+| 6 | no tracebacks visible to user                                                  | pass |
+| 7 | recall.log shows structured `tool=<name>` lines                                | pass — verified via `tail -f ~/.recall/logs/recall.log \| grep '"tool":'` |
+
+### Observations
+
+The verification value of this client surface is bug-surfacing, not
+UX evaluation. AI-assistant-mediated tool dispatch exposes correctness
+issues (data shape, response timing, error rendering) that don't
+require visual UI. Findings F1-F5 above were all surfaced through
+this surface; tooling for client-specific UX (palette rendering,
+natural-language summary quality, tool-call discoverability in the
+chat flow) is the natural complement run from the macOS desktop +
+IDE clients below.
+
+One additional observation worth noting (not a bug, observable in
+this surface): when assistant reasoning uses `commands_after` against
+a zsh-only index and gets empty `following`, the LLM correctly
+recognizes the absence of useful sequence data and either suggests
+running `recall index --source atuin` or moves to a different tool —
+suggesting the LLM has reasonable failure recovery behavior even
+with the current silent-degradation bug. F1's fix improves this
+further by making the limitation explicit at the protocol layer.
+
+### Known issues
+
+- See top-level **"Pending fixes (3.13.5)"** section. F1-F5 were all
+  surfaced from this client surface during the 2026-05-09 — 2026-05-10
+  verification sessions.
 
 ---
 

--- a/docs/clients-tested.md
+++ b/docs/clients-tested.md
@@ -1,5 +1,19 @@
 # clients-tested.md
 
+> **v1 launch status:** 1/6 entries filled with real observations
+> (Claude.ai web MCP connector — the bug-surfacing surface that
+> produced findings F1-F5 below). Per the locked launch-readiness
+> contract (CLAUDE.md "v1 launch-readiness gate (3.13)"), 4 macOS
+> desktop/IDE clients + 1 Windows entry are explicitly `not yet
+> verified` — manual UX verification is human-eyeball work the v1
+> launch sprint isn't budgeting time for. Tracked as v1.0.1
+> deliverable: "macOS desktop client matrix expansion."
+>
+> The Claude.ai web entry is the load-bearing one: it surfaced the
+> findings the v1 README's trust signal depends on, and the F1-F5
+> evidence trail in this file documents recall's posture toward
+> shipping bugs honestly with explicit fix paths.
+
 Per-client verification matrix for `recall-mcp`. Each entry captures:
 client+OS+recall versions, date verified, the 7-item assertion-
 checklist outcome from [`tests/manual_smoke.md`](../tests/manual_smoke.md)

--- a/docs/clients-tested.md
+++ b/docs/clients-tested.md
@@ -47,6 +47,109 @@ Before v1 announce:
 
 ---
 
+## Pending fixes (3.13.5)
+
+Surfaced during the Claude.ai MCP connector verification session that
+exercised real tools/call dispatch against an indexed corpus. These
+findings predate 3.13 (introduced in 3.10's tool implementations);
+3.13's matrix surfaced them. Both ship as a 3.13.5 hotfix on a fresh
+branch after 3.13 squash-merges.
+
+### F1 — `commands_after` returns empty `following` for non-atuin indexes
+
+**Symptom:** When the index has only zsh/bash entries (no atuin),
+`commands_after` returns `pattern_match` correctly but `following`
+is always `[]`. The tool *runs successfully* (no error) but provides
+no sequence data — silent UX degradation.
+
+**Root cause:** zsh/bash readers don't capture `session_id`. The
+SQL lookup `WHERE session_id = ? AND ts > ...` returns no rows when
+`session_id IS NULL`. Handler explicitly skips the lookup in that
+case (returns empty `following`). Behavior is consistent with the
+description's "in the same session" wording but the description
+under-emphasizes the atuin dependency.
+
+**Fix path (3.13.5):** Make `commands_after` atuin-required like
+`failed_recently`. Add `state: no_atuin_source` check; return clean
+state-error with this message:
+
+> commands_after requires atuin source data for session-boundary
+> tracking. Your index doesn't include atuin records. Install atuin
+> (https://atuin.sh) to capture session ids for new commands, then
+> run 'recall index' to incrementally pick them up. (Without atuin,
+> sequence tracking would conflate commands across concurrent
+> terminal sessions.)
+
+The parenthetical surfaces the correctness reason — closes the
+"couldn't you just guess?" question for the LLM client (and through
+it the user) before it gets asked. Cross-session conflation is real:
+two terminals running independently produce ts-adjacent commands
+with no causal relationship.
+
+**Why not a timestamp-adjacency heuristic?** Considered (option (b)
+in 3.13's diagnosis); rejected. Single-terminal users would get
+useful results; multi-terminal users would get occasional incorrect
+causality. A semantic-search tool's value depends on result
+trustworthiness; conflating sessions corrupts that.
+
+**Cost:** ~10 LoC + 1 fixture update + tool description tweak.
+
+### F2 — only 4 of 6 tools registered in MCP client
+
+**Symptom:** `recent` and `failed_recently` not appearing in the
+client's tool palette. Other 4 tools (search, find_in_project,
+commands_after, command_stats) appear normally.
+
+**Hypothesis:** The 4 visible tools all have at least one required
+parameter (`query` or `pattern`); the 2 missing tools have no
+required parameters (all fields default or nullable). Pydantic v2's
+`model_json_schema()` **omits the `"required"` key entirely when
+no fields are required** (vs emitting `"required": []`). Some MCP
+clients filter or hide tools whose schema lacks a `required`
+declaration.
+
+**Verification needed before fix (3.13.5 plan should include):**
+1. Capture actual tools/list JSON from a fresh Claude Desktop session
+   against current main; compare to 3.10 manual smoke baseline.
+2. Test the same recall server against one other MCP client (Cursor
+   or Zed). If `recent`/`failed_recently` appear there → Claude.ai
+   MCP connector-specific filtering, fix framed as "compatibility
+   shim." If they don't appear in any client → JSON Schema convention
+   issue, fix framed as "spec compliance."
+
+**Fix path (3.13.5) — same regardless of root cause:**
+3-line `setdefault("required", [])` in `_tool_for()`:
+
+```python
+def _tool_for(name, description, model):
+    schema = model.model_json_schema()
+    schema.setdefault("required", [])  # MCP-client compatibility
+    return Tool(name=name, description=description, inputSchema=schema)
+```
+
+Doesn't change semantics; makes the schema explicit. Backwards-
+compatible with clients that already work.
+
+### Per-client cross-reference
+
+Each client's "Known Issues" subsection below cross-references this
+"Pending fixes (3.13.5)" section rather than restating the findings.
+After 3.13.5 lands, entries here update from "Pending fix" to
+"Fixed in 3.13.5" with the squash-commit SHA — preserves the
+evidence trail.
+
+### Finding 3 — README framing (Phase 4, not 3.13.5)
+
+Most metadata fields (cwd, hostname, ts, session_id) are null for
+zsh/bash entries because those readers don't capture them. Not a
+bug; an honest limitation. Phase 4 README needs framing as value-
+add: "atuin integration enables richest UX; without it, semantic
+search + frequency analytics still work fully." Familiar
+"install X for full experience" pattern. Tracked as Phase 4
+deferred entry in CLAUDE.md.
+
+---
+
 ## Cursor (macOS)
 
 | field           | value |
@@ -76,7 +179,10 @@ or notably bad)_
 
 ### Known issues
 
-- (none yet — fill bullet list as observations accumulate)
+- See top-level **"Pending fixes (3.13.5)"** section for server-side
+  findings (F1: commands_after non-atuin; F2: only-4-of-6-tools). Both
+  apply to any client and ship as a 3.13.5 hotfix.
+- _(client-specific quirks: maintainer fills as observations accumulate)_
 
 ---
 
@@ -116,7 +222,10 @@ or notably bad)_
 
 ### Known issues
 
-- (none yet)
+- See top-level **"Pending fixes (3.13.5)"** section for server-side
+  findings (F1: commands_after non-atuin; F2: only-4-of-6-tools). Both
+  apply to any client and ship as a 3.13.5 hotfix.
+- _(client-specific quirks: maintainer fills as observations accumulate)_
 
 ---
 
@@ -147,7 +256,10 @@ _(maintainer fills in)_
 
 ### Known issues
 
-- (none yet)
+- See top-level **"Pending fixes (3.13.5)"** section for server-side
+  findings (F1: commands_after non-atuin; F2: only-4-of-6-tools). Both
+  apply to any client and ship as a 3.13.5 hotfix.
+- _(client-specific quirks: maintainer fills as observations accumulate)_
 
 ---
 
@@ -178,7 +290,10 @@ _(maintainer fills in)_
 
 ### Known issues
 
-- (none yet)
+- See top-level **"Pending fixes (3.13.5)"** section for server-side
+  findings (F1: commands_after non-atuin; F2: only-4-of-6-tools). Both
+  apply to any client and ship as a 3.13.5 hotfix.
+- _(client-specific quirks: maintainer fills as observations accumulate)_
 
 ---
 
@@ -221,4 +336,7 @@ _(maintainer fills in pre-launch via UTM VM session)_
 
 ### Known issues
 
-- (none yet)
+- See top-level **"Pending fixes (3.13.5)"** section for server-side
+  findings (F1: commands_after non-atuin; F2: only-4-of-6-tools). Both
+  apply to any client and ship as a 3.13.5 hotfix.
+- _(client-specific quirks: maintainer fills as observations accumulate)_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,6 +284,13 @@ def _resolve_recall_binary() -> str:
     """
     bin_dir = Path(sys.executable).parent
     recall_bin = bin_dir / "recall"
+    # Windows console-script convention: pyproject.toml's
+    # [project.scripts] entry produces `recall.exe` under
+    # <venv>\Scripts\ on Windows. Path doesn't auto-append the
+    # extension; check both forms. (3.13 stdio-windows lane is
+    # the first Windows CI run.)
+    if not recall_bin.exists() and sys.platform == "win32":
+        recall_bin = bin_dir / "recall.exe"
     if not recall_bin.exists():
         raise RuntimeError(
             f"recall console script not found at {recall_bin}. Did `uv sync` install the package?"

--- a/tests/manual_smoke.md
+++ b/tests/manual_smoke.md
@@ -1,24 +1,30 @@
-# Manual smoke procedure — MCP server (3.9 + 3.10)
+# Manual smoke procedure — MCP server
 
-This is the only thing exercising actual stdio-transport before
-3.11 lands the CI subprocess test. It's where SDK-runner integration
-bugs and stdout-pollution leaks would surface (the kind the in-process
-tests in `test_server.py` and `test_tools.py` can't reach).
+> **Per-client outcomes are recorded in [`docs/clients-tested.md`](../docs/clients-tested.md).**
+> This file is the canonical *procedure* (HOW to verify); `clients-tested.md`
+> is the *evidence* file (WHAT was observed when a client was last
+> verified). Update both when verifying a new client, and re-verify
+> per the cadence policy in CLAUDE.md "v1 launch-readiness gate (3.13)".
+
+This procedure exercises actual stdio-transport against `recall serve`.
+It catches SDK-runner integration bugs, stdout-pollution leaks, and
+real-MCP-client UX dimensions (rendering, tool palette behavior,
+natural-language summary quality) that the CI lanes can't reach.
 
 Run this procedure manually after every meaningful change to
 `src/recall/server.py`, `src/recall/tools.py`, `src/recall/cli.py::serve_cmd`,
 or `pyproject.toml` (mcp dep).
 
-The procedure has three sections:
-  - **Section A: 3.9-era initialize handshake** (was the whole smoke at 3.9).
-  - **Section B: 3.10 tool-call exercise** — one JSON-RPC `tools/call`
-    per tool, asserting shape and stdout cleanliness. Requires an
-    indexed DB at `~/.recall/db.sqlite` (build via `recall index`).
-  - **Section C: live MCP-client smoke (Claude Desktop)** — the
-    closest 3.10 will come to real-client testing before 3.13.
-    Configure `verify/3.10` server, confirm `tools/list` renders all
-    six with descriptions, run at least one `tools/call` and confirm
-    the response renders. Surface anything off-looking before merge.
+The procedure has four sections:
+  - **Section A: initialize handshake** (single-frame transport check).
+  - **Section B: tool-call exercise** — one JSON-RPC `tools/call`
+    per tool against a real indexed DB.
+  - **Section C: live MCP-client smoke (any client)** — the canonical
+    procedure each client in `docs/clients-tested.md` runs through.
+    Covers tool-palette rendering, error-as-guidance, embedder
+    lazy-load UX, natural-language summary quality.
+  - **Section D: stdio-cleanliness suite (3.11 / 3.12 local mirror)** —
+    M-series local re-run of the dedicated CI lanes.
 
 ## Prerequisites
 
@@ -279,66 +285,109 @@ count]` pairs), `mean_duration_ms`, `success_rate`, `by_source`,
 
 ---
 
-## Section C — Live MCP-client smoke (Claude Desktop)
+## Section C — Live MCP-client smoke (any client)
 
-This is the closest 3.10 will come to real-MCP-client testing
-before 3.13. Required step before squash-merge.
+The canonical procedure for verifying any MCP client against
+`recall-mcp`. Each entry in [`docs/clients-tested.md`](../docs/clients-tested.md)
+records the outcome of running this procedure on a specific
+client+OS+version combination.
 
-### Procedure
+Tests dimensions CI can't reach: tool-palette rendering, tool
+descriptions rendering, error-as-guidance vs error-as-traceback,
+embedder lazy-load UX, response rendering quality, and natural-
+language summary quality from the client's LLM.
 
-1. **Configure Claude Desktop** to use the `verify/3.10` build of
-   `recall serve`. Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+### Configuration
 
-   ```json
-   {
-     "mcpServers": {
-       "recall": {
-         "command": "/path/to/repo/.venv/bin/recall",
-         "args": ["serve"]
-       }
-     }
-   }
+Each client has its own MCP-server config file/UI:
+
+- **Claude Desktop (macOS)**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Claude Desktop (Windows)**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Cursor (macOS)**: Cursor settings → MCP → add server entry
+- **Zed (macOS)**: `~/.config/zed/settings.json` under `context_servers`
+- **Cline VS Code (macOS)**: VS Code settings → Cline MCP server config
+
+Common config shape (paths/keys vary per client):
+
+```json
+{
+  "mcpServers": {
+    "recall": {
+      "command": "/path/to/repo/.venv/bin/recall",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Restart the client after editing config.
+
+### Procedure (run all 7 checks; record outcomes in clients-tested.md)
+
+1. **tools/list renders all 6 tools in palette.** Click the tools
+   indicator (icon/chip varies per client) and confirm: search,
+   find_in_project, commands_after, failed_recently, command_stats,
+   recent.
+
+2. **Tool descriptions render fully** (or note truncation if the
+   client truncates). Search description is the longest — this is
+   the truncation canary.
+
+3. **tools/call recent succeeds + renders readably.** Ask the client
+   something like "use the recent tool to show me my last 5 commands."
+   The response should render as a readable list/table/summary, not
+   a raw JSON wall.
+
+4. **tools/call command_stats with `pattern: "%"` (validation error)**
+   returns a clean user-facing error. Ask the client: "use
+   command_stats with pattern equal to a single percent sign." Confirm
+   the error renders as guidance — NOT a stack trace, NOT a JSON wall.
+
+5. **tools/call search triggers embedder lazy-load (~5s on first
+   call); client shows progress indicator OR returns result without
+   frozen UI.** Ask the client: "search my shell history for git
+   commands." First call pays the model load cost; subsequent calls
+   are fast.
+
+6. **No tracebacks visible** in the client UI for any of the above.
+
+7. **`~/.recall/logs/recall.log` has structured `tool=<name>
+   ok|state_error|value_error count=<N>` lines.** Run this in a
+   terminal to monitor live:
+   ```bash
+   tail -f ~/.recall/logs/recall.log | grep '"tool":'
    ```
+   Query text NOT logged (CLAUDE.md Q8 policy).
 
-   Restart Claude Desktop.
+### Natural-language summary observation
 
-2. **Confirm tools/list renders**: open a new conversation, click the
-   tools indicator (hammer/wrench icon), and verify all six tools
-   appear with their descriptions:
-   - search
-   - find_in_project
-   - commands_after
-   - failed_recently
-   - command_stats
-   - recent
+After each tools/call (steps 3, 4, 5), **observe how the client's
+LLM summarizes the result to the end user**. Note in the
+`docs/clients-tested.md` observations field if summary quality is:
 
-3. **Run at least one tools/call**: ask Claude Desktop something
-   like "use the recent tool to show me my last 5 commands" or
-   "search my shell history for git commands". Confirm:
-   - The response renders in the UI (no raw error blob)
-   - Result text is scrubbed (no real secrets visible — should be
-     `<REDACTED:...>` markers if your history had any)
-   - No stack-traces visible to the user
+- **Notably good**: uses structure intelligently (e.g. renders results
+  as a numbered table, picks meaningful fields, asks a useful
+  follow-up like "want help with anything related?")
+- **Notably bad**: verbatim JSON dump, ignores fields, hallucinates
+  content not in the result, fails to recover from a state-error
 
-4. **Check `~/.recall/logs/recall.log`** has structured INFO lines
-   like `tool=recent ok count=5`. Query text NOT logged (Q8 policy).
-
-### Assertion checklist
-
-- [ ] All six tools listed in Claude Desktop's tool palette
-- [ ] Tool descriptions render (truncated by client UI is fine, but
-      no missing/empty descriptions)
-- [ ] At least one `tools/call` runs end-to-end and renders
-- [ ] No tracebacks visible in client UI
-- [ ] No stdout-pollution (would manifest as broken JSON / dropped
-      messages from the client's perspective)
+This dimension is the hardest to test elsewhere; it materially
+affects v1 launch UX and is a key trust signal.
 
 ### What to do if anything looks off
 
-Surface the issue in the squash-merge PR comment **before merge**.
-This is the last opportunity to catch a real-MCP-client UX regression
-before the 3.13 documented-clients-tested checklist runs across
-multiple clients.
+If a test fails or surfaces a UX regression:
+
+1. **Capture the observation** in the relevant `docs/clients-tested.md`
+   entry's `Known Issues` subsection. Be specific: client+version,
+   what was expected, what was observed.
+2. **Decide severity:**
+   - **Recall bug** (response shape wrong, server crash, tracebacks
+     visible) → block 3.13 / file as v1 launch-blocker.
+   - **Client-side UX quirk** (truncation, layout glitch, slow first
+     render) → file as v1.x deferred entry; ship v1 with caveat.
+   - **Unclear** → investigate before deciding. Don't ship with
+     unclear state.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes Phase 3. The v1 launch-readiness gate.

Where 3.10-3.12 built the protocol surface + automated CI gates, 3.13 verifies the end-to-end UX across real MCP clients — the dimensions CI can't reach (rendering, tool palette behavior, natural-language summary quality, error-message readability).

**Two surfaces:**

1. **Stdio Windows CI lane (`stdio-windows`)** — permanent gate on `windows-latest`, py3.12. Subset of stdio cleanliness (A+C+E+AST+T201; cold-cache D excluded — HF/torch Windows variation isn't stdio-cleanliness territory). Per F1 lock: combined approach with permanent Windows CI + manual UTM VM session pre-launch.

2. **Per-client UX verification matrix** at `docs/clients-tested.md`. Five entries (4 macOS + 1 Windows) capture the 7-item assertion-checklist outcome from `manual_smoke.md` Section C, free-text observations including natural-language summary quality from each client's LLM, and a Known Issues subsection.

`tests/manual_smoke.md` Section C reframed from "Claude Desktop" (3.10) to "any client" (3.13). Procedure file = HOW to verify; matrix file = WHAT was observed.

CLAUDE.md adds new top-level "v1 launch-readiness gate (3.13)" section: 5-client matrix definition, cadence policy, launch-readiness contract, pre-launch UTM VM setup notes, Phase 4 boundary, and the Windows test triage rule (locked decision tree for `stdio-windows` failures).

## Plan-locked refinements baked in

- **Observation-truth merge gate**: squash-merge requires entries reflect *real observations*, not placeholder text. §9 early-bail-out: ship 1/4 honestly > ship 4/4 carelessly.
- **Windows test triage rule** (CLAUDE.md §5): explicit decision tree for `stdio-windows` failures — recall bug vs Windows test-infra quirk vs unclear. Future contributors inherit the rule.
- **Tag-uniqueness within pipeline blocks** (carried from 3.12) — already enforced by loader.

## Test plan

- [x] `pytest -m "not embed"` — 319 passed (no source changes affecting collection)
- [x] `pytest -k scrub` — 122 canary clean
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy src` — 26 files, 0 errors
- [ ] **CI watch**:
  - new `stdio-windows` lane goes green (~10-15s expected)
  - existing 10 lanes unchanged
- [ ] **Maintainer-paced (post-merge)**: fill 4 macOS entries in `docs/clients-tested.md` per locked §9 order: Cursor → Claude Desktop → Zed → Cline. Each entry-fill push re-runs CI cheaply.
- [ ] **Pre-launch**: UTM VM session fills 5th Windows entry. Squash-merge gate is "all 5 entries reflect real observations."

## CI on this PR

Expected lanes (11/11):
```
fast (macos × py3.11/3.12/3.13)    pass  ~1m each
fast (ubuntu × py3.11/3.12/3.13)   pass  ~1m each
embed (ubuntu / py3.12)            pass  ~20-23m
stdio (ubuntu / py3.12)            pass  ~50s
stdio-windows (windows / py3.12)   pass  ~10-15s   ← NEW
fixture drift warning              pass  ~5s (no warning expected)
scrubber test count canary         skip   (scrub.py untouched)
```

If the new `stdio-windows` lane fails on the first run, apply the locked triage rule (CLAUDE.md §5 "Windows test triage rule") and surface the result before maintainer-paced entry-fill begins.

## Files

```
 docs/clients-tested.md       +224  (NEW — template + 5 entry skeletons)
 tests/manual_smoke.md        +177/-70  (Section C reframe + 7-item checklist)
 CLAUDE.md                    +113  (v1 gate section + triage rule)
 .github/workflows/ci.yml     +39   (stdio-windows lane)
 tests/conftest.py            +7    (Windows .exe fallback)
```

After this PR + Phase 4 (README + PyPI publish + sample fixtures), v1.0 announce is unblocked.