### PR TITLE
fix(tools): F1 + F2 + F4 (Commit 3.13.5)

### DIFF
--- a/docs/clients-tested.md
+++ b/docs/clients-tested.md
@@ -61,15 +61,41 @@ Before v1 announce:
 
 ---
 
-## Pending fixes (3.13.5)
+## Fixed in 3.13.5
 
-Surfaced during the Claude.ai MCP connector verification session that
-exercised real tools/call dispatch against an indexed corpus. These
-findings predate 3.13 (introduced in 3.10's tool implementations);
-3.13's matrix surfaced them. Both ship as a 3.13.5 hotfix on a fresh
-branch after 3.13 squash-merges.
+Findings F1-F5 were surfaced during the Claude.ai MCP connector
+verification session that exercised real tools/call dispatch against
+an indexed corpus. The findings predate 3.13 (introduced in 3.10's
+tool implementations); 3.13's matrix surfaced them. 3.13.5 lands
+the fixes as a follow-up commit on main:
 
-### F1 — `commands_after` returns empty `following` for non-atuin indexes
+- **F1** ✅ `commands_after` now atuin-required (parallel to
+  `failed_recently`); returns clean state-error with the locked
+  message text. The parenthetical surfaces the cross-session-
+  conflation correctness reason.
+- **F2** ✅ Baseline `setdefault("required", [])` shim applied
+  in `_tool_for()`; every tool's JSON schema now explicitly
+  declares `required` (even as `[]`). `find_in_project` filtering
+  investigation deferred to matrix verification (Cursor / Zed
+  entries will determine whether shim alone is sufficient or a
+  follow-up fix is needed).
+- **F4** ✅ `recent` uses hybrid ORDER BY: real-ts rows first
+  (by ts DESC), then ts=0 rows by id DESC (insertion order as
+  time-proxy). Tool description updated to surface the fallback
+  honestly: "approximates time-ordering for typical single-session
+  indexing."
+- **F5** ⚠️ No fix shipped — bug observed once, asyncio dispatch
+  serialization hypothesis empirically refuted by the 2026-05-10
+  diagnostic spike, no reproduction path identified. Monitoring
+  framing unchanged: user-feedback channel for v1.0.1 with
+  recall.log + py-spy capture instructions.
+
+The detailed root-cause analysis + fix paths for each finding live
+in the subsections below — preserved as the evidence trail readers
+of clients-tested.md inherit. References to the 3.13.5 squash commit
+SHA are filled by `git log` (this file's history).
+
+### F1 — `commands_after` returns empty `following` for non-atuin indexes ✅ Fixed in 3.13.5
 
 **Symptom:** When the index has only zsh/bash entries (no atuin),
 `commands_after` returns `pattern_match` correctly but `following`
@@ -108,7 +134,7 @@ trustworthiness; conflating sessions corrupts that.
 
 **Cost:** ~10 LoC + 1 fixture update + tool description tweak.
 
-### F2 — `find_in_project` not appearing in client tool palette (5/6 visible)
+### F2 — `find_in_project` not appearing in client tool palette (5/6 visible) ✅ Shim landed in 3.13.5; investigation pending
 
 **Symptom:** Out of the 6 registered tools, 5 appear in the Claude.ai
 MCP connector's tool palette: `search`, `commands_after`,
@@ -161,7 +187,7 @@ filing as upstream client bug).
 **Cost:** ~3 LoC for the shim + ~30 min investigation effort + fix
 shape TBD. Probably ~10-30 LoC total.
 
-### F4 — `recent` returns wrong-order data on zsh-only indexes
+### F4 — `recent` returns wrong-order data on zsh-only indexes ✅ Fixed in 3.13.5
 
 **Symptom:** `recent` (the canonical "show me my most recent
 commands" tool) returns OLDEST-first commands when the index is
@@ -208,7 +234,7 @@ same pattern; v1 only `recent` needs it for non-atuin users.
 **Cost:** ~5 LoC (SQL change) + 1-2 fixture updates + tool
 description tweak.
 
-### F5 — `failed_recently` 4+ minute hang (observed once, monitoring)
+### F5 — `failed_recently` 4+ minute hang (observed once, monitoring) ⚠️ No code fix; monitoring
 
 **Symptom (single observation):** During a Claude.ai MCP connector
 session that had previously made multiple semantic search calls

--- a/src/recall/tools.py
+++ b/src/recall/tools.py
@@ -114,6 +114,19 @@ NO_ATUIN_SOURCE_MSG = (
     "Install atuin and run 'recall index --source atuin'."
 )
 
+# F1 (3.13.5): commands_after also requires atuin. Different framing than
+# failed_recently's exit-code dependency — commands_after needs session_id
+# for session-boundary tracking. The parenthetical surfaces the correctness
+# reason (cross-session conflation) so the LLM client passes it to the user
+# rather than re-asking "couldn't you just guess?".
+COMMANDS_AFTER_NO_ATUIN_MSG = (
+    "commands_after requires atuin source data for session-boundary tracking. "
+    "Your index doesn't include atuin records. Install atuin (https://atuin.sh) "
+    "to capture session ids for new commands, then run 'recall index' to "
+    "incrementally pick them up. (Without atuin, sequence tracking would "
+    "conflate commands across concurrent terminal sessions.)"
+)
+
 CWD_CONTEXT_MISSING_MSG = (
     "find_in_project needs a working-directory context. Pass an explicit 'cwd' "
     "argument or set the MCP_CLIENT_CWD environment variable when launching the "
@@ -395,7 +408,17 @@ async def _handle_recent(
 ) -> tuple[dict[str, Any], int]:
     """List most-recent commands, optionally filtered by cwd/host.
 
-    Doesn't need the embedder; just an indexed-ts ORDER BY.
+    Doesn't need the embedder; just an indexed-ts ORDER BY with the
+    F4 hybrid fallback (3.13.5).
+
+    F4 fix: zsh/bash readers don't always capture timestamps; entries
+    emit ``ts=0`` per the HistorySource protocol. With all rows tied
+    at ts=0, the original ``ORDER BY ts DESC, id ASC`` collapsed to
+    id-ASC = oldest-insertion-first — contradicting the tool's
+    "most-recent" semantics. The hybrid ORDER BY treats real-ts rows
+    first (ts DESC), then ts=0 rows by ``id DESC`` (insertion order
+    as time-proxy — most recent insertion first). For typical
+    single-session indexing, id DESC approximates time-ordering.
     """
     inp = RecentInput.model_validate(arguments)
 
@@ -418,11 +441,15 @@ async def _handle_recent(
         params.append(inp.host)
 
     where_sql = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    # F4 hybrid ORDER BY: real-ts rows first (sorted by ts DESC), then
+    # ts=0 rows (sorted by id DESC as insertion-order time-proxy).
+    # The CASE WHEN expression partitions rows into two groups (0=real-ts,
+    # 1=unknown-ts); within each group, the secondary keys order them.
     sql = (
         "SELECT id, source, text_scrubbed, text_hash, cwd, hostname, "
         "exit_code, duration_ms, session_id, ts "
         f"FROM commands{where_sql} "
-        "ORDER BY ts DESC, id ASC LIMIT ?"
+        "ORDER BY (CASE WHEN ts > 0 THEN 0 ELSE 1 END), ts DESC, id DESC LIMIT ?"
     )
     params.append(inp.limit)
     rows = db_conn.execute(sql, params).fetchall()
@@ -562,6 +589,11 @@ async def _handle_commands_after(
     commands in the same session, time-ordered. Useful for 'what did I
     run after the failing migration?' queries.
 
+    Requires the atuin source for session tracking (F1 fix at 3.13.5).
+    zsh/bash readers don't capture session_id; without it, "after" can't
+    be defined without conflating commands across concurrent terminal
+    sessions. Returns a clean state-error when no atuin records exist.
+
     No regex flag (locked Q2). Pattern is treated as a literal substring.
     """
     inp = CommandsAfterInput.model_validate(arguments)
@@ -571,6 +603,15 @@ async def _handle_commands_after(
     if err is not None:
         return err
     assert db_conn is not None
+
+    # F1 (3.13.5): atuin presence check before pattern matching.
+    # Same shape as failed_recently's check; surfaces the dependency
+    # explicitly rather than silently degrading to empty `following`.
+    has_atuin_row = db_conn.execute(
+        "SELECT 1 FROM commands WHERE source = 'atuin' LIMIT 1"
+    ).fetchone()
+    if not has_atuin_row:
+        return _state_error_response(COMMANDS_AFTER_NO_ATUIN_MSG)
 
     pat = "%" + _escape_like(inp.pattern) + "%"
     matches = db_conn.execute(
@@ -811,10 +852,20 @@ async def _handle_find_in_project(
 
 
 def _tool_for(name: str, description: str, model: type[BaseModel]) -> Tool:
+    schema = model.model_json_schema()
+    # F2 (3.13.5) compatibility shim: Pydantic 2 omits the "required"
+    # key from JSON Schema when no fields are required (vs emitting
+    # "required": []). Some MCP clients filter or hide tools whose
+    # schema lacks a `required` declaration. Setting the default
+    # explicitly is spec-compatible and harmless for clients that
+    # already work. (Doesn't fix find_in_project's specific filtering;
+    # that's a separate investigation. This is the unconditional
+    # baseline.)
+    schema.setdefault("required", [])
     return Tool(
         name=name,
         description=description,
-        inputSchema=model.model_json_schema(),
+        inputSchema=schema,
     )
 
 
@@ -837,7 +888,8 @@ TOOLS: list[Tool] = [
         "commands_after",
         "Find commands matching the substring `pattern`; for each match, "
         "return the next ~3 commands run in the same session. Useful for "
-        "'what did I run after the failing migration?' queries.",
+        "'what did I run after the failing migration?' queries. Requires "
+        "the atuin source for session tracking.",
         CommandsAfterInput,
     ),
     _tool_for(
@@ -855,7 +907,10 @@ TOOLS: list[Tool] = [
     _tool_for(
         "recent",
         "Most-recent commands, optionally filtered by cwd prefix or hostname. "
-        "Time-ordered DESC, then id ASC for tie-break.",
+        "Time-ordered DESC. For shell sources that don't capture timestamps "
+        "(zsh and bash history files), commands are ordered by insertion "
+        "order (most recently indexed first), which approximates time-ordering "
+        "for typical single-session indexing.",
         RecentInput,
     ),
 ]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -572,6 +572,84 @@ class TestRecentHandler:
         assert len(h) == 16
         assert all(c in "0123456789abcdef" for c in h)
 
+    # F4 (3.13.5): hybrid ORDER BY for ts=0 fallback.
+    #
+    # zsh/bash readers emit ts=0 when EXTENDED_HISTORY is absent. With
+    # all rows tied at ts=0, pre-fix `ORDER BY ts DESC, id ASC` collapsed
+    # to id-ASC = oldest-first. The fix uses
+    # `ORDER BY (CASE WHEN ts > 0 THEN 0 ELSE 1 END), ts DESC, id DESC`
+    # so real-ts rows come first, then ts=0 rows by id-DESC (most-recent
+    # insertion first as time-proxy).
+
+    def test_all_ts_zero_falls_back_to_id_desc(self, db_with_index, tmp_path: Path) -> None:
+        """F4 marquee test: when all ts=0 (typical zsh-only index), `recent`
+        returns most-recent-INSERTED first (id DESC), NOT oldest-first.
+
+        This is the regression-prevention test for the silent bug F4
+        identified — pre-fix behavior was id ASC, contradicting the tool's
+        'most-recent' semantics.
+        """
+        _insert_command(db_with_index, source="zsh", text="first", ts=0)
+        _insert_command(db_with_index, source="zsh", text="second", ts=0)
+        _insert_command(db_with_index, source="zsh", text="third", ts=0)
+        state = _make_state(db_path=tmp_path / "db.sqlite", has_index=True)
+        payload, count, _ = _run(
+            dispatch_tool(
+                "recent",
+                {"limit": 10},
+                state=state,
+                db_conn=db_with_index,
+                encode=_make_fake_encode({}),
+            )
+        )
+        assert count == 3
+        texts = [h["text"] for h in payload["results"]]
+        # id DESC (most-recently-inserted first), NOT id ASC
+        assert texts == ["third", "second", "first"]
+        # Off-by-one defense: explicit assertion that catches accidental
+        # id ASC if a future refactor regresses the SQL.
+        ids = [h["id"] for h in payload["results"]]
+        assert ids[0] > ids[-1], (
+            "F4 regression: results ordered id-ASC (oldest-first); "
+            "expected id-DESC (most-recent insertion first) when all ts=0"
+        )
+
+    def test_mixed_ts_orders_real_ts_first_then_id_desc(
+        self, db_with_index, tmp_path: Path
+    ) -> None:
+        """Mixed-source index: atuin rows have real ts; zsh rows have ts=0.
+        Hybrid ORDER BY should put atuin rows first (by ts DESC) then zsh
+        rows (by id DESC).
+        """
+        # Insertion order: zsh (ts=0), then atuin (ts=200), then zsh (ts=0),
+        # then atuin (ts=100). Result should be:
+        #   atuin ts=200 first (real-ts group, sorted DESC)
+        #   atuin ts=100 second
+        #   zsh row inserted later (higher id) third (ts=0 group, id DESC)
+        #   zsh row inserted earlier (lower id) fourth
+        _insert_command(db_with_index, source="zsh", text="zsh-old-insert", ts=0)
+        _insert_command(db_with_index, source="atuin", text="atuin-newer", ts=200)
+        _insert_command(db_with_index, source="zsh", text="zsh-newer-insert", ts=0)
+        _insert_command(db_with_index, source="atuin", text="atuin-older", ts=100)
+        state = _make_state(db_path=tmp_path / "db.sqlite", has_index=True)
+        payload, count, _ = _run(
+            dispatch_tool(
+                "recent",
+                {"limit": 10},
+                state=state,
+                db_conn=db_with_index,
+                encode=_make_fake_encode({}),
+            )
+        )
+        assert count == 4
+        texts = [h["text"] for h in payload["results"]]
+        assert texts == [
+            "atuin-newer",  # real-ts group, ts=200 first
+            "atuin-older",  # real-ts group, ts=100 second
+            "zsh-newer-insert",  # ts=0 group, higher id (later insertion)
+            "zsh-old-insert",  # ts=0 group, lower id (earlier insertion)
+        ]
+
 
 class TestCommandStatsHandler:
     def test_aggregates(self, db_with_index, tmp_path: Path) -> None:
@@ -715,10 +793,20 @@ class TestCommandsAfterHandler:
         following_texts = [c["text"] for c in seq["following"]]
         assert following_texts == ["check status", "rollback"]
 
-    def test_session_none_returns_empty_following(self, db_with_index, tmp_path: Path) -> None:
+    def test_no_atuin_source_returns_clean_error(self, db_with_index, tmp_path: Path) -> None:
+        """F1 (3.13.5): commands_after requires atuin source data for
+        session-boundary tracking. Non-atuin index returns a clean state-
+        error with the user-facing message; the message surfaces the
+        correctness reason (cross-session conflation).
+
+        Pre-F1 behavior was silent UX degradation (matched pattern,
+        empty `following`); replaced by explicit error surface so the
+        LLM client + user understand why no sequence data is available.
+        """
+        # Only zsh rows — no atuin records in the index.
         _insert_command(db_with_index, source="zsh", text="orphan_cmd", ts=100, session_id=None)
         state = _make_state(db_path=tmp_path / "db.sqlite", has_index=True)
-        payload, _count, _ = _run(
+        payload, count, is_err = _run(
             dispatch_tool(
                 "commands_after",
                 {"pattern": "orphan_cmd"},
@@ -727,7 +815,14 @@ class TestCommandsAfterHandler:
                 encode=_make_fake_encode({}),
             )
         )
-        assert payload["results"][0]["following"] == []
+        assert is_err is True
+        assert count == 0
+        msg = payload["error"]
+        assert "commands_after requires atuin" in msg
+        # Locked message text includes the cross-session-conflation
+        # parenthetical surfacing the correctness reason
+        assert "conflate commands across concurrent terminal sessions" in msg
+        assert "https://atuin.sh" in msg
 
 
 class TestSearchHandler:
@@ -860,6 +955,34 @@ class TestToolsRegistry:
         for t in TOOLS:
             assert t.inputSchema is not None
             assert "properties" in t.inputSchema, f"{t.name} missing properties"
+
+    def test_each_tool_schema_includes_required_key(self) -> None:
+        """F2 (3.13.5) shim: every tool's JSON Schema must include the
+        ``required`` key (even if []), not omit it.
+
+        Pydantic 2 omits the key when no fields are required; some MCP
+        clients filter tools whose schema lacks the declaration. The
+        shim in `_tool_for()` sets it explicitly. This test asserts the
+        contract.
+        """
+        from recall.tools import TOOLS
+
+        for t in TOOLS:
+            assert "required" in t.inputSchema, (
+                f"{t.name} schema missing 'required' key — F2 shim broken"
+            )
+            assert isinstance(t.inputSchema["required"], list), f"{t.name} 'required' is not a list"
+        # Sanity: at least one tool with required parameters (search has
+        # 'query'); at least one without (recent has all defaults). The
+        # shim affects the no-required-params case specifically.
+        recent_schema = next(t.inputSchema for t in TOOLS if t.name == "recent")
+        assert recent_schema["required"] == [], (
+            "recent has no required params; shim should produce []"
+        )
+        search_schema = next(t.inputSchema for t in TOOLS if t.name == "search")
+        assert search_schema["required"] == ["query"], (
+            "search's required params should be unchanged by the shim"
+        )
 
     def test_descriptions_are_non_empty(self) -> None:
         from recall.tools import TOOLS


### PR DESCRIPTION
## Summary

Fix-it commit for the four findings the 3.13 clients-tested matrix surfaced from the Claude.ai MCP connector verification. Findings predate 3.13 (introduced in 3.10's tool implementations); 3.13's matrix exposed them; 3.13.5 fixes them.

| finding | fix |
| ------- | --- |
| **F1** ✅ | `commands_after` now atuin-required (parallel to `failed_recently`); returns clean state-error with locked message text + cross-session-conflation parenthetical |
| **F2** ✅ | `setdefault("required", [])` shim in `_tool_for()`; every tool's JSON schema explicitly declares `required` (even `[]`). `find_in_project` investigation pending in macOS matrix verification |
| **F4** ✅ | `recent` uses hybrid `ORDER BY (CASE WHEN ts > 0 THEN 0 ELSE 1 END), ts DESC, id DESC`. Real-ts rows first; ts=0 fallback by `id DESC` (insertion order as time-proxy) |
| **F5** ⚠️ | No code fix. Bug observed once; asyncio dispatch hypothesis empirically refuted by 2026-05-10 spike. Monitoring framing with v1.0.1 user-feedback channel |

## Test plan

- [x] `pytest -m "not embed"` — 322 passed (was 319; +3 new, −1 replaced)
- [x] `pytest tests/test_tools.py` — 68 (was 65; +3 net)
- [x] `pytest -k scrub` — 122 canary clean
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy src` — 26 files, 0 errors
- [x] F4 off-by-one defense: explicit `assert ids[0] > ids[-1]` in `test_all_ts_zero_falls_back_to_id_desc` — catches accidental id-ASC regression
- [ ] CI 11/11 green on PR
- [ ] Squash-merge per cadence

## Locked refinements verified

- ✅ F4 fallback is `id DESC` (silent bug being fixed was `id ASC`); regression test asserts `ids[0] > ids[-1]` for the all-ts=0 case
- ✅ recent description matches §refinement 2 verbatim ("approximates time-ordering for typical single-session indexing")
- ✅ docs/clients-tested.md heading transitioned "Pending fixes (3.13.5)" → "Fixed in 3.13.5" with locked 4-bullet status format

## Files

```
 src/recall/tools.py      +65   (F1 + F2 + F4 + tool description tweaks)
 tests/test_tools.py      +129  (4 new tests, 1 replaced)
 docs/clients-tested.md   +50   ("Fixed in 3.13.5" status + ✅/⚠️ annotations)
```

After this lands, Phase 3 is fully closed. Phase 4 begins (README + PyPI publish + sample fixtures).